### PR TITLE
fix code to pass cpu.rs module test  at ch3.3

### DIFF
--- a/code/ch3.3/src/cpu.rs
+++ b/code/ch3.3/src/cpu.rs
@@ -229,7 +229,7 @@ impl CPU {
 
     pub fn load_and_run(&mut self, program: Vec<u8>) {
         self.load(program);
-        self.reset();
+        self.program_counter = self.mem_read_u16(0xFFFC);
         self.run()
     }
 


### PR DESCRIPTION
to be honest , I do not think we should put reset() in load_and_run() , after load the program , if we force cpu reset,all the pre-configured parameter like prgrame file , register statu,will all be lost. definitely we can't pass any test. so I suggest change the code.
as the PR change.
The test result as below
![image](https://user-images.githubusercontent.com/16858675/116387673-9aeb6b80-a84d-11eb-9b54-2ad71f8b070e.png)
