### PR TITLE
errata: get_operand_address should take &mut self

### DIFF
--- a/src/chapter_3_2.md
+++ b/src/chapter_3_2.md
@@ -178,7 +178,7 @@ pub enum AddressingMode {
 
 impl CPU {
    // ...
-   fn get_operand_address(&self, mode: &AddressingMode) -> u16 {
+   fn get_operand_address(&mut self, mode: &AddressingMode) -> u16 {
 
        match mode {
            AddressingMode::Immediate => self.program_counter,


### PR DESCRIPTION
because mem_read takes &mut self