### PR TITLE
Fix all unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 book
 target/
 pacman.nes
+.DS_Store

--- a/code/ch3.3/src/cpu.rs
+++ b/code/ch3.3/src/cpu.rs
@@ -229,7 +229,7 @@ impl CPU {
 
     pub fn load_and_run(&mut self, program: Vec<u8>) {
         self.load(program);
-        self.reset();
+        self.program_counter = self.mem_read_u16(0xFFFC);
         self.run()
     }
 
@@ -836,7 +836,9 @@ mod test {
     #[test]
     fn test_0xa9_lda_immediate_load_data() {
         let mut cpu = CPU::new();
+
         cpu.load_and_run(vec![0xa9, 0x05, 0x00]);
+
         assert_eq!(cpu.register_a, 5);
         assert!(cpu.status.bits() & 0b0000_0010 == 0b00);
         assert!(cpu.status.bits() & 0b1000_0000 == 0);
@@ -845,10 +847,9 @@ mod test {
     #[test]
     fn test_0xaa_tax_move_a_to_x() {
         let mut cpu = CPU::new();
-        cpu.load(vec![0xaa, 0x00]);
-        cpu.reset();
         cpu.register_a = 10;
-        cpu.run();
+
+        cpu.load_and_run(vec![0xaa, 0x00]);
 
         assert_eq!(cpu.register_x, 10)
     }
@@ -856,6 +857,7 @@ mod test {
     #[test]
     fn test_5_ops_working_together() {
         let mut cpu = CPU::new();
+
         cpu.load_and_run(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
 
         assert_eq!(cpu.register_x, 0xc1)
@@ -864,10 +866,9 @@ mod test {
     #[test]
     fn test_inx_overflow() {
         let mut cpu = CPU::new();
-        cpu.load(vec![0xe8, 0xe8, 0x00]);
-        cpu.reset();
         cpu.register_x = 0xff;
-        cpu.run();
+
+        cpu.load_and_run(vec![0xe8, 0xe8, 0x00]);
 
         assert_eq!(cpu.register_x, 1)
     }

--- a/code/ch3.4/src/cpu.rs
+++ b/code/ch3.4/src/cpu.rs
@@ -237,7 +237,7 @@ impl CPU {
 
     pub fn load_and_run(&mut self, program: Vec<u8>) {
         self.load(program);
-        self.reset();
+        self.program_counter = self.mem_read_u16(0xFFFC);
         self.run()
     }
 
@@ -854,7 +854,9 @@ mod test {
     #[test]
     fn test_0xa9_lda_immediate_load_data() {
         let mut cpu = CPU::new();
+
         cpu.load_and_run(vec![0xa9, 0x05, 0x00]);
+
         assert_eq!(cpu.register_a, 5);
         assert!(cpu.status.bits() & 0b0000_0010 == 0b00);
         assert!(cpu.status.bits() & 0b1000_0000 == 0);
@@ -864,6 +866,7 @@ mod test {
     fn test_0xaa_tax_move_a_to_x() {
         let mut cpu = CPU::new();
         cpu.register_a = 10;
+
         cpu.load_and_run(vec![0xaa, 0x00]);
 
         assert_eq!(cpu.register_x, 10)
@@ -872,6 +875,7 @@ mod test {
     #[test]
     fn test_5_ops_working_together() {
         let mut cpu = CPU::new();
+
         cpu.load_and_run(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
 
         assert_eq!(cpu.register_x, 0xc1)
@@ -881,6 +885,7 @@ mod test {
     fn test_inx_overflow() {
         let mut cpu = CPU::new();
         cpu.register_x = 0xff;
+
         cpu.load_and_run(vec![0xe8, 0xe8, 0x00]);
 
         assert_eq!(cpu.register_x, 1)

--- a/code/ch4/src/cpu.rs
+++ b/code/ch4/src/cpu.rs
@@ -245,15 +245,15 @@ impl CPU {
 
     pub fn load_and_run(&mut self, program: Vec<u8>) {
         self.load(program);
-        self.reset();
+        self.program_counter = self.mem_read_u16(0xFFFC);
         self.run()
     }
 
     pub fn load(&mut self, program: Vec<u8>) {
         for i in 0..(program.len() as u16) {
-            self.mem_write(0x0600 + i, program[i as usize]);
+            self.mem_write(0x0000 + i, program[i as usize]);
         }
-        self.mem_write_u16(0xFFFC, 0x0600);
+        self.mem_write_u16(0xFFFC, 0x0000);
     }
 
     pub fn reset(&mut self) {

--- a/code/ch5.1/src/bus.rs
+++ b/code/ch5.1/src/bus.rs
@@ -103,7 +103,7 @@ mod test {
 
     #[test]
     fn test_mem_read_write_to_ram() {
-        let mut bus = Bus::new(test::test_rom());
+        let mut bus = Bus::new(test::test_rom(vec![]));
         bus.mem_write(0x01, 0x55);
         assert_eq!(bus.mem_read(0x01), 0x55);
     }

--- a/code/ch5.1/src/cartridge.rs
+++ b/code/ch5.1/src/cartridge.rs
@@ -83,13 +83,16 @@ pub mod test {
         result
     }
 
-    pub fn test_rom() -> Rom {
+    pub fn test_rom(program: Vec<u8>) -> Rom {
+        let mut pgp_rom_contents = program;
+        pgp_rom_contents.resize(2 * PRG_ROM_PAGE_SIZE, 0);
+
         let test_rom = create_rom(TestRom {
             header: vec![
                 0x4E, 0x45, 0x53, 0x1A, 0x02, 0x01, 0x31, 00, 00, 00, 00, 00, 00, 00, 00, 00,
             ],
             trainer: None,
-            pgp_rom: vec![1; 2 * PRG_ROM_PAGE_SIZE],
+            pgp_rom: pgp_rom_contents,
             chr_rom: vec![2; 1 * CHR_ROM_PAGE_SIZE],
         });
 

--- a/code/ch5.1/src/cpu.rs
+++ b/code/ch5.1/src/cpu.rs
@@ -98,7 +98,7 @@ impl CPU {
             register_x: 0,
             register_y: 0,
             stack_pointer: STACK_RESET,
-            program_counter: 0,
+            program_counter: 0x8000,
             status: CpuFlags::from_bits_truncate(0b100100),
             bus: bus,
         }
@@ -246,13 +246,6 @@ impl CPU {
     fn iny(&mut self) {
         self.register_y = self.register_y.wrapping_add(1);
         self.update_zero_and_negative_flags(self.register_y);
-    }
-
-    pub fn load_and_run(&mut self, program: Vec<u8>) {
-        self.load(program);
-        self.reset();
-        self.program_counter = 0x0600;
-        self.run()
     }
 
     pub fn load(&mut self, program: Vec<u8>) {
@@ -1116,9 +1109,11 @@ mod test {
 
     #[test]
     fn test_0xa9_lda_immediate_load_data() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom(vec![0xa9, 0x05, 0x00]));
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0x05, 0x00]);
+
+        cpu.run();
+
         assert_eq!(cpu.register_a, 5);
         assert!(cpu.status.bits() & 0b0000_0010 == 0b00);
         assert!(cpu.status.bits() & 0b1000_0000 == 0);
@@ -1126,40 +1121,43 @@ mod test {
 
     #[test]
     fn test_0xaa_tax_move_a_to_x() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom(vec![0xaa, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.register_a = 10;
-        cpu.load_and_run(vec![0xaa, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 10)
     }
 
     #[test]
     fn test_5_ops_working_together() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]));
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 0xc1)
     }
 
     #[test]
     fn test_inx_overflow() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom(vec![0xe8, 0xe8, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.register_x = 0xff;
-        cpu.load_and_run(vec![0xe8, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 1)
     }
 
     #[test]
     fn test_lda_from_memory() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom(vec![0xa5, 0x10, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.mem_write(0x10, 0x55);
 
-        cpu.load_and_run(vec![0xa5, 0x10, 0x00]);
+        cpu.run();
 
         assert_eq!(cpu.register_a, 0x55);
     }

--- a/code/ch5.1/src/trace.rs
+++ b/code/ch5.1/src/trace.rs
@@ -138,7 +138,7 @@ mod test {
 
     #[test]
     fn test_format_trace() {
-        let mut bus = Bus::new(test_rom());
+        let mut bus = Bus::new(test_rom(vec![]));
         bus.mem_write(100, 0xa2);
         bus.mem_write(101, 0x01);
         bus.mem_write(102, 0xca);
@@ -170,7 +170,7 @@ mod test {
 
     #[test]
     fn test_format_mem_access() {
-        let mut bus = Bus::new(test_rom());
+        let mut bus = Bus::new(test_rom(vec![]));
         // ORA ($33), Y
         bus.mem_write(100, 0x11);
         bus.mem_write(101, 0x33);

--- a/code/ch5/src/cartridge.rs
+++ b/code/ch5/src/cartridge.rs
@@ -83,13 +83,16 @@ pub mod test {
         result
     }
 
-    pub fn test_rom() -> Rom {
+    pub fn test_rom(program: Vec<u8>) -> Rom {
+        let mut pgp_rom_contents = program;
+        pgp_rom_contents.resize(2 * PRG_ROM_PAGE_SIZE, 0);
+
         let test_rom = create_rom(TestRom {
             header: vec![
                 0x4E, 0x45, 0x53, 0x1A, 0x02, 0x01, 0x31, 00, 00, 00, 00, 00, 00, 00, 00, 00,
             ],
             trainer: None,
-            pgp_rom: vec![1; 2 * PRG_ROM_PAGE_SIZE],
+            pgp_rom: pgp_rom_contents,
             chr_rom: vec![2; 1 * CHR_ROM_PAGE_SIZE],
         });
 

--- a/code/ch5/src/cpu.rs
+++ b/code/ch5/src/cpu.rs
@@ -98,7 +98,7 @@ impl CPU {
             register_x: 0,
             register_y: 0,
             stack_pointer: STACK_RESET,
-            program_counter: 0,
+            program_counter: 0x8000,
             status: CpuFlags::from_bits_truncate(0b100100),
             bus: bus,
         }
@@ -241,12 +241,6 @@ impl CPU {
     fn iny(&mut self) {
         self.register_y = self.register_y.wrapping_add(1);
         self.update_zero_and_negative_flags(self.register_y);
-    }
-
-    pub fn load_and_run(&mut self, program: Vec<u8>) {
-        self.load(program);
-        self.reset();
-        self.run()
     }
 
     pub fn load(&mut self, program: Vec<u8>) {
@@ -864,9 +858,11 @@ mod test {
 
     #[test]
     fn test_0xa9_lda_immediate_load_data() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom(vec![0xa9, 0x05, 0x00]));
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0x05, 0x00]);
+
+        cpu.run();
+
         assert_eq!(cpu.register_a, 5);
         assert!(cpu.status.bits() & 0b0000_0010 == 0b00);
         assert!(cpu.status.bits() & 0b1000_0000 == 0);
@@ -874,40 +870,43 @@ mod test {
 
     #[test]
     fn test_0xaa_tax_move_a_to_x() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom(vec![0xaa, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.register_a = 10;
-        cpu.load_and_run(vec![0xaa, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 10)
     }
 
     #[test]
     fn test_5_ops_working_together() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]));
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 0xc1)
     }
 
     #[test]
     fn test_inx_overflow() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom(vec![0xe8, 0xe8, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.register_x = 0xff;
-        cpu.load_and_run(vec![0xe8, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 1)
     }
 
     #[test]
     fn test_lda_from_memory() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom(vec![0xa5, 0x10, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.mem_write(0x10, 0x55);
 
-        cpu.load_and_run(vec![0xa5, 0x10, 0x00]);
+        cpu.run();
 
         assert_eq!(cpu.register_a, 0x55);
     }

--- a/code/ch6.1/src/cartridge.rs
+++ b/code/ch6.1/src/cartridge.rs
@@ -84,12 +84,19 @@ pub mod test {
     }
 
     pub fn test_rom() -> Rom {
+        test_rom_containing(vec![])
+    }
+
+    pub fn test_rom_containing(program: Vec<u8>) -> Rom {
+        let mut pgp_rom_contents = program;
+        pgp_rom_contents.resize(2 * PRG_ROM_PAGE_SIZE, 0);
+
         let test_rom = create_rom(TestRom {
             header: vec![
                 0x4E, 0x45, 0x53, 0x1A, 0x02, 0x01, 0x31, 00, 00, 00, 00, 00, 00, 00, 00, 00,
             ],
             trainer: None,
-            pgp_rom: vec![1; 2 * PRG_ROM_PAGE_SIZE],
+            pgp_rom: pgp_rom_contents,
             chr_rom: vec![2; 1 * CHR_ROM_PAGE_SIZE],
         });
 

--- a/code/ch6.1/src/cpu.rs
+++ b/code/ch6.1/src/cpu.rs
@@ -98,7 +98,7 @@ impl CPU {
             register_x: 0,
             register_y: 0,
             stack_pointer: STACK_RESET,
-            program_counter: 0,
+            program_counter: 0x8000,
             status: CpuFlags::from_bits_truncate(0b100100),
             bus: bus,
         }
@@ -246,13 +246,6 @@ impl CPU {
     fn iny(&mut self) {
         self.register_y = self.register_y.wrapping_add(1);
         self.update_zero_and_negative_flags(self.register_y);
-    }
-
-    pub fn load_and_run(&mut self, program: Vec<u8>) {
-        self.load(program);
-        self.reset();
-        self.program_counter = 0x0600;
-        self.run()
     }
 
     pub fn load(&mut self, program: Vec<u8>) {
@@ -1116,9 +1109,11 @@ mod test {
 
     #[test]
     fn test_0xa9_lda_immediate_load_data() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xa9, 0x05, 0x00]));
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0x05, 0x00]);
+
+        cpu.run();
+
         assert_eq!(cpu.register_a, 5);
         assert!(cpu.status.bits() & 0b0000_0010 == 0b00);
         assert!(cpu.status.bits() & 0b1000_0000 == 0);
@@ -1126,40 +1121,43 @@ mod test {
 
     #[test]
     fn test_0xaa_tax_move_a_to_x() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xaa, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.register_a = 10;
-        cpu.load_and_run(vec![0xaa, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 10)
     }
 
     #[test]
     fn test_5_ops_working_together() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]));
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 0xc1)
     }
 
     #[test]
     fn test_inx_overflow() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xe8, 0xe8, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.register_x = 0xff;
-        cpu.load_and_run(vec![0xe8, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 1)
     }
 
     #[test]
     fn test_lda_from_memory() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xa5, 0x10, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.mem_write(0x10, 0x55);
 
-        cpu.load_and_run(vec![0xa5, 0x10, 0x00]);
+        cpu.run();
 
         assert_eq!(cpu.register_a, 0x55);
     }

--- a/code/ch6.2/src/cartridge.rs
+++ b/code/ch6.2/src/cartridge.rs
@@ -84,12 +84,19 @@ pub mod test {
     }
 
     pub fn test_rom() -> Rom {
+        test_rom_containing(vec![])
+    }
+
+    pub fn test_rom_containing(program: Vec<u8>) -> Rom {
+        let mut pgp_rom_contents = program;
+        pgp_rom_contents.resize(2 * PRG_ROM_PAGE_SIZE, 0);
+
         let test_rom = create_rom(TestRom {
             header: vec![
                 0x4E, 0x45, 0x53, 0x1A, 0x02, 0x01, 0x31, 00, 00, 00, 00, 00, 00, 00, 00, 00,
             ],
             trainer: None,
-            pgp_rom: vec![1; 2 * PRG_ROM_PAGE_SIZE],
+            pgp_rom: pgp_rom_contents,
             chr_rom: vec![2; 1 * CHR_ROM_PAGE_SIZE],
         });
 

--- a/code/ch6.2/src/cpu.rs
+++ b/code/ch6.2/src/cpu.rs
@@ -124,7 +124,7 @@ impl CPU {
             register_x: 0,
             register_y: 0,
             stack_pointer: STACK_RESET,
-            program_counter: 0,
+            program_counter: 0x8000,
             status: CpuFlags::from_bits_truncate(0b100100),
             bus: bus,
         }
@@ -294,13 +294,6 @@ impl CPU {
     fn iny(&mut self) {
         self.register_y = self.register_y.wrapping_add(1);
         self.update_zero_and_negative_flags(self.register_y);
-    }
-
-    pub fn load_and_run(&mut self, program: Vec<u8>) {
-        self.load(program);
-        self.reset();
-        self.program_counter = 0x0600;
-        self.run()
     }
 
     pub fn load(&mut self, program: Vec<u8>) {
@@ -1205,9 +1198,11 @@ mod test {
 
     #[test]
     fn test_0xa9_lda_immediate_load_data() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xa9, 0x05, 0x00]));
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0x05, 0x00]);
+
+        cpu.run();
+
         assert_eq!(cpu.register_a, 5);
         assert!(cpu.status.bits() & 0b0000_0010 == 0b00);
         assert!(cpu.status.bits() & 0b1000_0000 == 0);
@@ -1215,40 +1210,43 @@ mod test {
 
     #[test]
     fn test_0xaa_tax_move_a_to_x() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xaa, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.register_a = 10;
-        cpu.load_and_run(vec![0xaa, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 10)
     }
 
     #[test]
     fn test_5_ops_working_together() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]));
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 0xc1)
     }
 
     #[test]
     fn test_inx_overflow() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xe8, 0xe8, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.register_x = 0xff;
-        cpu.load_and_run(vec![0xe8, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 1)
     }
 
     #[test]
     fn test_lda_from_memory() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xa5, 0x10, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.mem_write(0x10, 0x55);
 
-        cpu.load_and_run(vec![0xa5, 0x10, 0x00]);
+        cpu.run();
 
         assert_eq!(cpu.register_a, 0x55);
     }

--- a/code/ch6.3/src/cartridge.rs
+++ b/code/ch6.3/src/cartridge.rs
@@ -84,12 +84,19 @@ pub mod test {
     }
 
     pub fn test_rom() -> Rom {
+        test_rom_containing(vec![])
+    }
+
+    pub fn test_rom_containing(program: Vec<u8>) -> Rom {
+        let mut pgp_rom_contents = program;
+        pgp_rom_contents.resize(2 * PRG_ROM_PAGE_SIZE, 0);
+
         let test_rom = create_rom(TestRom {
             header: vec![
                 0x4E, 0x45, 0x53, 0x1A, 0x02, 0x01, 0x31, 00, 00, 00, 00, 00, 00, 00, 00, 00,
             ],
             trainer: None,
-            pgp_rom: vec![1; 2 * PRG_ROM_PAGE_SIZE],
+            pgp_rom: pgp_rom_contents,
             chr_rom: vec![2; 1 * CHR_ROM_PAGE_SIZE],
         });
 

--- a/code/ch6.3/src/cpu.rs
+++ b/code/ch6.3/src/cpu.rs
@@ -124,7 +124,7 @@ impl CPU {
             register_x: 0,
             register_y: 0,
             stack_pointer: STACK_RESET,
-            program_counter: 0,
+            program_counter: 0x8000,
             status: CpuFlags::from_bits_truncate(0b100100),
             bus: bus,
         }
@@ -294,13 +294,6 @@ impl CPU {
     fn iny(&mut self) {
         self.register_y = self.register_y.wrapping_add(1);
         self.update_zero_and_negative_flags(self.register_y);
-    }
-
-    pub fn load_and_run(&mut self, program: Vec<u8>) {
-        self.load(program);
-        self.reset();
-        self.program_counter = 0x0600;
-        self.run()
     }
 
     pub fn load(&mut self, program: Vec<u8>) {
@@ -1205,9 +1198,11 @@ mod test {
 
     #[test]
     fn test_0xa9_lda_immediate_load_data() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xa9, 0x05, 0x00]));
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0x05, 0x00]);
+
+        cpu.run();
+
         assert_eq!(cpu.register_a, 5);
         assert!(cpu.status.bits() & 0b0000_0010 == 0b00);
         assert!(cpu.status.bits() & 0b1000_0000 == 0);
@@ -1215,40 +1210,43 @@ mod test {
 
     #[test]
     fn test_0xaa_tax_move_a_to_x() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xaa, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.register_a = 10;
-        cpu.load_and_run(vec![0xaa, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 10)
     }
 
     #[test]
     fn test_5_ops_working_together() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]));
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 0xc1)
     }
 
     #[test]
     fn test_inx_overflow() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xe8, 0xe8, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.register_x = 0xff;
-        cpu.load_and_run(vec![0xe8, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 1)
     }
 
     #[test]
     fn test_lda_from_memory() {
-        let bus = Bus::new(test::test_rom());
+        let bus = Bus::new(test::test_rom_containing(vec![0xa5, 0x10, 0x00]));
         let mut cpu = CPU::new(bus);
         cpu.mem_write(0x10, 0x55);
 
-        cpu.load_and_run(vec![0xa5, 0x10, 0x00]);
+        cpu.run();
 
         assert_eq!(cpu.register_a, 0x55);
     }

--- a/code/ch6.4/src/cartridge.rs
+++ b/code/ch6.4/src/cartridge.rs
@@ -84,12 +84,19 @@ pub mod test {
     }
 
     pub fn test_rom() -> Rom {
+        test_rom_containing(vec![])
+    }
+
+    pub fn test_rom_containing(program: Vec<u8>) -> Rom {
+        let mut pgp_rom_contents = program;
+        pgp_rom_contents.resize(2 * PRG_ROM_PAGE_SIZE, 0);
+
         let test_rom = create_rom(TestRom {
             header: vec![
                 0x4E, 0x45, 0x53, 0x1A, 0x02, 0x01, 0x31, 00, 00, 00, 00, 00, 00, 00, 00, 00,
             ],
             trainer: None,
-            pgp_rom: vec![1; 2 * PRG_ROM_PAGE_SIZE],
+            pgp_rom: pgp_rom_contents,
             chr_rom: vec![2; 1 * CHR_ROM_PAGE_SIZE],
         });
 

--- a/code/ch7/src/bus.rs
+++ b/code/ch7/src/bus.rs
@@ -205,7 +205,7 @@ mod test {
 
     #[test]
     fn test_mem_read_write_to_ram() {
-        let mut bus = Bus::new(test::test_rom(), |ppu: &NesPPU, &mut Joypad| {});
+        let mut bus = Bus::new(test::test_rom(), |_ppu, _joypad| {});
         bus.mem_write(0x01, 0x55);
         assert_eq!(bus.mem_read(0x01), 0x55);
     }

--- a/code/ch7/src/cartridge.rs
+++ b/code/ch7/src/cartridge.rs
@@ -84,12 +84,19 @@ pub mod test {
     }
 
     pub fn test_rom() -> Rom {
+        test_rom_containing(vec![])
+    }
+
+    pub fn test_rom_containing(program: Vec<u8>) -> Rom {
+        let mut pgp_rom_contents = program;
+        pgp_rom_contents.resize(2 * PRG_ROM_PAGE_SIZE, 0);
+
         let test_rom = create_rom(TestRom {
             header: vec![
                 0x4E, 0x45, 0x53, 0x1A, 0x02, 0x01, 0x31, 00, 00, 00, 00, 00, 00, 00, 00, 00,
             ],
             trainer: None,
-            pgp_rom: vec![1; 2 * PRG_ROM_PAGE_SIZE],
+            pgp_rom: pgp_rom_contents,
             chr_rom: vec![2; 1 * CHR_ROM_PAGE_SIZE],
         });
 

--- a/code/ch7/src/cpu.rs
+++ b/code/ch7/src/cpu.rs
@@ -122,7 +122,7 @@ impl<'a> CPU<'a> {
             register_x: 0,
             register_y: 0,
             stack_pointer: STACK_RESET,
-            program_counter: 0,
+            program_counter: 0x8000,
             status: CpuFlags::from_bits_truncate(0b100100),
             bus: bus,
         }
@@ -1197,54 +1197,58 @@ impl<'a> CPU<'a> {
 mod test {
     use super::*;
     use crate::cartridge::test;
-    use crate::ppu::NesPPU;
 
     #[test]
     fn test_0xa9_lda_immediate_load_data() {
-        let bus = Bus::new(test::test_rom(), |ppu: &NesPPU| {});
+        let bus = Bus::new(test::test_rom_containing(vec![0xa9, 0x05, 0x00]), |_ppu, _joypad| {});
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0x05, 0x00]);
+
+        cpu.run();
+
         assert_eq!(cpu.register_a, 5);
         assert!(cpu.status.bits() & 0b0000_0010 == 0b00);
         assert!(cpu.status.bits() & 0b1000_0000 == 0);
     }
 
     #[test]
-    fn test_0xaa_tax_move_a_to_x() {
-        let bus = Bus::new(test::test_rom(), |ppu: &NesPPU| {});
+    fn test_0xaa_tax_move_a_to_x() { 
+        let bus = Bus::new(test::test_rom_containing(vec![0xaa, 0x00]), |_ppu, _joypad| {});
         let mut cpu = CPU::new(bus);
         cpu.register_a = 10;
-        cpu.load_and_run(vec![0xaa, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 10)
     }
 
     #[test]
     fn test_5_ops_working_together() {
-        let bus = Bus::new(test::test_rom(), |ppu: &NesPPU| {});
+        let bus = Bus::new(test::test_rom_containing(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]), |_ppu, _joypad| {});
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 0xc1)
     }
 
     #[test]
     fn test_inx_overflow() {
-        let bus = Bus::new(test::test_rom(), |ppu: &NesPPU| {});
+        let bus = Bus::new(test::test_rom_containing(vec![0xe8, 0xe8, 0x00]), |_ppu, _joypad| {});
         let mut cpu = CPU::new(bus);
         cpu.register_x = 0xff;
-        cpu.load_and_run(vec![0xe8, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 1)
     }
 
     #[test]
     fn test_lda_from_memory() {
-        let bus = Bus::new(test::test_rom(), |ppu: &NesPPU| {});
+        let bus = Bus::new(test::test_rom_containing(vec![0xa5, 0x10, 0x00]), |_ppu, _joypad| {});
         let mut cpu = CPU::new(bus);
         cpu.mem_write(0x10, 0x55);
 
-        cpu.load_and_run(vec![0xa5, 0x10, 0x00]);
+        cpu.run();
 
         assert_eq!(cpu.register_a, 0x55);
     }

--- a/code/ch7/src/trace.rs
+++ b/code/ch7/src/trace.rs
@@ -135,11 +135,10 @@ mod test {
     use super::*;
     use crate::bus::Bus;
     use crate::cartridge::test::test_rom;
-    use crate::ppu::NesPPU;
 
     #[test]
     fn test_format_trace() {
-        let mut bus = Bus::new(test_rom(), |ppu: &NesPPU| {});
+        let mut bus = Bus::new(test_rom(), |_ppu, _joypad| {});
         bus.mem_write(100, 0xa2);
         bus.mem_write(101, 0x01);
         bus.mem_write(102, 0xca);
@@ -171,7 +170,7 @@ mod test {
 
     #[test]
     fn test_format_mem_access() {
-        let mut bus = Bus::new(test_rom(), |ppu: &NesPPU| {});
+        let mut bus = Bus::new(test_rom(), |_ppu, _joypad| {});
         // ORA ($33), Y
         bus.mem_write(100, 0x11);
         bus.mem_write(101, 0x33);

--- a/code/ch8/src/bus.rs
+++ b/code/ch8/src/bus.rs
@@ -209,7 +209,7 @@ mod test {
 
     #[test]
     fn test_mem_read_write_to_ram() {
-        let mut bus = Bus::new(test::test_rom(), |ppu: &NesPPU, &mut Joypad| {});
+        let mut bus = Bus::new(test::test_rom(), |_ppu, _joypad| {});
         bus.mem_write(0x01, 0x55);
         assert_eq!(bus.mem_read(0x01), 0x55);
     }

--- a/code/ch8/src/cartridge.rs
+++ b/code/ch8/src/cartridge.rs
@@ -84,12 +84,19 @@ pub mod test {
     }
 
     pub fn test_rom() -> Rom {
+        test_rom_containing(vec![])
+    }
+
+    pub fn test_rom_containing(program: Vec<u8>) -> Rom {
+        let mut pgp_rom_contents = program;
+        pgp_rom_contents.resize(2 * PRG_ROM_PAGE_SIZE, 0);
+
         let test_rom = create_rom(TestRom {
             header: vec![
                 0x4E, 0x45, 0x53, 0x1A, 0x02, 0x01, 0x31, 00, 00, 00, 00, 00, 00, 00, 00, 00,
             ],
             trainer: None,
-            pgp_rom: vec![1; 2 * PRG_ROM_PAGE_SIZE],
+            pgp_rom: pgp_rom_contents,
             chr_rom: vec![2; 1 * CHR_ROM_PAGE_SIZE],
         });
 

--- a/code/ch8/src/cpu.rs
+++ b/code/ch8/src/cpu.rs
@@ -132,7 +132,7 @@ impl<'a> CPU<'a> {
             register_x: 0,
             register_y: 0,
             stack_pointer: STACK_RESET,
-            program_counter: 0,
+            program_counter: 0x8000,
             status: CpuFlags::from_bits_truncate(0b100100),
             bus: bus,
         }
@@ -1213,13 +1213,14 @@ impl<'a> CPU<'a> {
 mod test {
     use super::*;
     use crate::cartridge::test;
-    use crate::ppu::NesPPU;
 
     #[test]
     fn test_0xa9_lda_immediate_load_data() {
-        let bus = Bus::new(test::test_rom(), |ppu: &NesPPU| {});
+        let bus = Bus::new(test::test_rom_containing(vec![0xa9, 0x05, 0x00]), |_ppu, _joypad| {});
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0x05, 0x00]);
+
+        cpu.run();
+
         assert_eq!(cpu.register_a, 5);
         assert!(cpu.status.bits() & 0b0000_0010 == 0b00);
         assert!(cpu.status.bits() & 0b1000_0000 == 0);
@@ -1227,40 +1228,43 @@ mod test {
 
     #[test]
     fn test_0xaa_tax_move_a_to_x() {
-        let bus = Bus::new(test::test_rom(), |ppu: &NesPPU| {});
+        let bus = Bus::new(test::test_rom_containing(vec![0xaa, 0x00]), |_ppu, _joypad| {});
         let mut cpu = CPU::new(bus);
         cpu.register_a = 10;
-        cpu.load_and_run(vec![0xaa, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 10)
     }
 
     #[test]
     fn test_5_ops_working_together() {
-        let bus = Bus::new(test::test_rom(), |ppu: &NesPPU| {});
+        let bus = Bus::new(test::test_rom_containing(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]), |_ppu, _joypad| {});
         let mut cpu = CPU::new(bus);
-        cpu.load_and_run(vec![0xa9, 0xc0, 0xaa, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 0xc1)
     }
 
     #[test]
     fn test_inx_overflow() {
-        let bus = Bus::new(test::test_rom(), |ppu: &NesPPU| {});
+        let bus = Bus::new(test::test_rom_containing(vec![0xe8, 0xe8, 0x00]), |_ppu, _joypad| {});
         let mut cpu = CPU::new(bus);
         cpu.register_x = 0xff;
-        cpu.load_and_run(vec![0xe8, 0xe8, 0x00]);
+
+        cpu.run();
 
         assert_eq!(cpu.register_x, 1)
     }
 
     #[test]
     fn test_lda_from_memory() {
-        let bus = Bus::new(test::test_rom(), |ppu: &NesPPU| {});
+        let bus = Bus::new(test::test_rom_containing(vec![0xa5, 0x10, 0x00]), |_ppu, _joypad| {});
         let mut cpu = CPU::new(bus);
         cpu.mem_write(0x10, 0x55);
 
-        cpu.load_and_run(vec![0xa5, 0x10, 0x00]);
+        cpu.run();
 
         assert_eq!(cpu.register_a, 0x55);
     }

--- a/code/ch8/src/trace.rs
+++ b/code/ch8/src/trace.rs
@@ -147,11 +147,10 @@ mod test {
     use super::*;
     use crate::bus::Bus;
     use crate::cartridge::test::test_rom;
-    use crate::ppu::NesPPU;
 
     #[test]
     fn test_format_trace() {
-        let mut bus = Bus::new(test_rom(), |ppu: &NesPPU| {});
+        let mut bus = Bus::new(test_rom(), |_ppu, _joypad| {});
         bus.mem_write(100, 0xa2);
         bus.mem_write(101, 0x01);
         bus.mem_write(102, 0xca);
@@ -183,7 +182,7 @@ mod test {
 
     #[test]
     fn test_format_mem_access() {
-        let mut bus = Bus::new(test_rom(), |ppu: &NesPPU| {});
+        let mut bus = Bus::new(test_rom(), |_ppu, _joypad| {});
         // ORA ($33), Y
         bus.mem_write(100, 0x11);
         bus.mem_write(101, 0x33);

--- a/code/testAll
+++ b/code/testAll
@@ -1,0 +1,6 @@
+#for f in $(find . -name Cargo.toml -printf '%h\n' | sort -u); do
+for f in $(find . -name *.toml -print0 | xargs -0 -n1 dirname | sort --unique); do
+  pushd $f > /dev/null;
+  cargo test;
+  popd > /dev/null;
+done

--- a/src/chapter_4.md
+++ b/src/chapter_4.md
@@ -111,7 +111,7 @@ impl Mem for Bus {
 }
 ```
 
-The last step is to replace direct access to RAM from CPU with access via BUS
+We then replace direct access to RAM from CPU with access via BUS
 
 ```rust
 pub struct CPU {
@@ -156,6 +156,17 @@ impl CPU {
    }
    // ...
 }
+```
+
+If we want our unit tests to still pass, we will temporarily adjust the `load` function to load our test programs to the new VRAM:
+
+```rust
+    pub fn load(&mut self, program: Vec<u8>) {
+        for i in 0..(program.len() as u16) {
+            self.mem_write(0x0000 + i, program[i as usize]);
+        }
+        self.mem_write_u16(0xFFFC, 0x0000);
+    }
 ```
 
 And that's pretty much it for now. Wasn't hard, right?


### PR DESCRIPTION
- Fixes all unit tests, similar to discussions in #9.
- Added script nes_ebook/code/testAll to make it easier to run every test. I'm new to rust but don't think we can use `cargo test --workspace` as we have duplicate package names, due to this being an incremental tutorial. It will probably only work on MacOS so we maybe just need to write separate dos/linus scripts, or there may be a better 'cargo' way?