### PR TITLE
Fix (some) compiler warnings

### DIFF
--- a/code/ch3.4/src/main.rs
+++ b/code/ch3.4/src/main.rs
@@ -8,7 +8,6 @@ use sdl2::EventPump;
 use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
-use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;
@@ -135,7 +134,7 @@ fn main() {
             canvas.present();
         }
 
-        ::std::thread::sleep(std::time::Duration::new(0, 70_000));
+        std::thread::sleep(std::time::Duration::new(0, 70_000));
     });
 
 }

--- a/code/ch4/src/main.rs
+++ b/code/ch4/src/main.rs
@@ -12,7 +12,6 @@ use sdl2::EventPump;
 use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
-use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;
@@ -141,7 +140,7 @@ fn main() {
             canvas.present();
         }
 
-        ::std::thread::sleep(std::time::Duration::new(0, 70_000));
+        std::thread::sleep(std::time::Duration::new(0, 70_000));
     });
 
 }

--- a/code/ch5.1/src/cartridge.rs
+++ b/code/ch5.1/src/cartridge.rs
@@ -4,9 +4,9 @@ const CHR_ROM_PAGE_SIZE: usize = 8192;
 
 #[derive(Debug, PartialEq)]
 pub enum Mirroring {
-    VERTICAL,
-    HORIZONTAL,
-    FOUR_SCREEN,
+    Vertical,
+    Horizontal,
+    FourScreen,
 }
 
 pub struct Rom {
@@ -32,9 +32,9 @@ impl Rom {
         let four_screen = raw[6] & 0b1000 != 0;
         let vertical_mirroring = raw[6] & 0b1 != 0;
         let screen_mirroring = match (four_screen, vertical_mirroring) {
-            (true, _) => Mirroring::FOUR_SCREEN,
-            (false, true) => Mirroring::VERTICAL,
-            (false, false) => Mirroring::HORIZONTAL,
+            (true, _) => Mirroring::FourScreen,
+            (false, true) => Mirroring::Vertical,
+            (false, false) => Mirroring::Horizontal,
         };
 
         let prg_rom_size = raw[4] as usize * PRG_ROM_PAGE_SIZE;
@@ -115,7 +115,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]
@@ -149,7 +149,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]

--- a/code/ch5.1/src/cpu.rs
+++ b/code/ch5.1/src/cpu.rs
@@ -1091,8 +1091,6 @@ impl CPU {
                     let data = self.register_y & ((mem_address >> 8) as u8 + 1);
                     self.mem_write(mem_address, data)
                 }
-
-                _ => todo!(),
             }
 
             if program_counter_state == self.program_counter {

--- a/code/ch5.1/src/cpu.rs
+++ b/code/ch5.1/src/cpu.rs
@@ -981,7 +981,7 @@ impl CPU {
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c
                 | 0x3c | 0x5c | 0x7c | 0xdc | 0xfc => {
                     let addr = self.get_operand_address(&opcode.mode);
-                    let data = self.mem_read(addr);
+                    let _data = self.mem_read(addr);
                     /* do nothing */
                 }
 

--- a/code/ch5.1/src/cpu.rs
+++ b/code/ch5.1/src/cpu.rs
@@ -975,7 +975,7 @@ impl CPU {
                     self.lsr_accumulator();
                 }
 
-                //todo: test for everything bellow
+                //todo: test for everything below
 
                 /* NOP read */
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c

--- a/code/ch5.1/src/main.rs
+++ b/code/ch5.1/src/main.rs
@@ -16,7 +16,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-// use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;
@@ -137,6 +136,6 @@ fn main() {
         //     canvas.present();
         // }
 
-        // ::std::thread::sleep(std::time::Duration::new(0, 70_000));
+        // std::thread::sleep(std::time::Duration::new(0, 70_000));
     });
 }

--- a/code/ch5.1/src/main.rs
+++ b/code/ch5.1/src/main.rs
@@ -6,90 +6,18 @@ pub mod trace;
 
 use bus::Bus;
 use cartridge::Rom;
-use cpu::Mem;
 use cpu::CPU;
 use trace::trace;
-// use rand::Rng;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
-use sdl2::EventPump;
 
 #[macro_use]
 extern crate lazy_static;
 
 #[macro_use]
 extern crate bitflags;
-
-fn color(byte: u8) -> Color {
-    match byte {
-        0 => sdl2::pixels::Color::BLACK,
-        1 => sdl2::pixels::Color::WHITE,
-        2 | 9 => sdl2::pixels::Color::GREY,
-        3 | 10 => sdl2::pixels::Color::RED,
-        4 | 11 => sdl2::pixels::Color::GREEN,
-        5 | 12 => sdl2::pixels::Color::BLUE,
-        6 | 13 => sdl2::pixels::Color::MAGENTA,
-        7 | 14 => sdl2::pixels::Color::YELLOW,
-        _ => sdl2::pixels::Color::CYAN,
-    }
-}
-
-fn read_screen_state(cpu: &CPU, frame: &mut [u8; 32 * 3 * 32]) -> bool {
-    let mut frame_idx = 0;
-    let mut update = false;
-    for i in 0x0200..0x600 {
-        let color_idx = cpu.mem_read(i as u16);
-        let (b1, b2, b3) = color(color_idx).rgb();
-        if frame[frame_idx] != b1 || frame[frame_idx + 1] != b2 || frame[frame_idx + 2] != b3 {
-            frame[frame_idx] = b1;
-            frame[frame_idx + 1] = b2;
-            frame[frame_idx + 2] = b3;
-            update = true;
-        }
-        frame_idx += 3;
-    }
-    update
-}
-
-fn handle_user_input(cpu: &mut CPU, event_pump: &mut EventPump) {
-    for event in event_pump.poll_iter() {
-        match event {
-            Event::Quit { .. }
-            | Event::KeyDown {
-                keycode: Some(Keycode::Escape),
-                ..
-            } => std::process::exit(0),
-            Event::KeyDown {
-                keycode: Some(Keycode::W),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x77);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::S),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x73);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::A),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x61);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::D),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x64);
-            }
-            _ => { /* do nothing */ }
-        }
-    }
-}
 
 fn main() {
     // init sdl2

--- a/code/ch5/src/cartridge.rs
+++ b/code/ch5/src/cartridge.rs
@@ -4,9 +4,9 @@ const CHR_ROM_PAGE_SIZE: usize = 8192;
 
 #[derive(Debug, PartialEq)]
 pub enum Mirroring {
-    VERTICAL,
-    HORIZONTAL,
-    FOUR_SCREEN,
+    Vertical,
+    Horizontal,
+    FourScreen,
 }
 
 pub struct Rom {
@@ -32,9 +32,9 @@ impl Rom {
         let four_screen = raw[6] & 0b1000 != 0;
         let vertical_mirroring = raw[6] & 0b1 != 0;
         let screen_mirroring = match (four_screen, vertical_mirroring) {
-            (true, _) => Mirroring::FOUR_SCREEN,
-            (false, true) => Mirroring::VERTICAL,
-            (false, false) => Mirroring::HORIZONTAL,
+            (true, _) => Mirroring::FourScreen,
+            (false, true) => Mirroring::Vertical,
+            (false, false) => Mirroring::Horizontal,
         };
 
         let prg_rom_size = raw[4] as usize * PRG_ROM_PAGE_SIZE;
@@ -115,7 +115,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]
@@ -149,7 +149,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]

--- a/code/ch5/src/main.rs
+++ b/code/ch5/src/main.rs
@@ -14,7 +14,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;
@@ -134,6 +133,6 @@ fn main() {
             canvas.present();
         }
 
-        ::std::thread::sleep(std::time::Duration::new(0, 70_000));
+        std::thread::sleep(std::time::Duration::new(0, 70_000));
     });
 }

--- a/code/ch6.1/src/cartridge.rs
+++ b/code/ch6.1/src/cartridge.rs
@@ -4,9 +4,9 @@ const CHR_ROM_PAGE_SIZE: usize = 8192;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Mirroring {
-    VERTICAL,
-    HORIZONTAL,
-    FOUR_SCREEN,
+    Vertical,
+    Horizontal,
+    FourScreen,
 }
 
 pub struct Rom {
@@ -32,9 +32,9 @@ impl Rom {
         let four_screen = raw[6] & 0b1000 != 0;
         let vertical_mirroring = raw[6] & 0b1 != 0;
         let screen_mirroring = match (four_screen, vertical_mirroring) {
-            (true, _) => Mirroring::FOUR_SCREEN,
-            (false, true) => Mirroring::VERTICAL,
-            (false, false) => Mirroring::HORIZONTAL,
+            (true, _) => Mirroring::FourScreen,
+            (false, true) => Mirroring::Vertical,
+            (false, false) => Mirroring::Horizontal,
         };
 
         let prg_rom_size = raw[4] as usize * PRG_ROM_PAGE_SIZE;
@@ -119,7 +119,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]
@@ -153,7 +153,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]

--- a/code/ch6.1/src/cpu.rs
+++ b/code/ch6.1/src/cpu.rs
@@ -1091,8 +1091,6 @@ impl CPU {
                     let data = self.register_y & ((mem_address >> 8) as u8 + 1);
                     self.mem_write(mem_address, data)
                 }
-
-                _ => todo!(),
             }
 
             if program_counter_state == self.program_counter {

--- a/code/ch6.1/src/cpu.rs
+++ b/code/ch6.1/src/cpu.rs
@@ -981,7 +981,7 @@ impl CPU {
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c
                 | 0x3c | 0x5c | 0x7c | 0xdc | 0xfc => {
                     let addr = self.get_operand_address(&opcode.mode);
-                    let data = self.mem_read(addr);
+                    let _data = self.mem_read(addr);
                     /* do nothing */
                 }
 

--- a/code/ch6.1/src/cpu.rs
+++ b/code/ch6.1/src/cpu.rs
@@ -975,7 +975,7 @@ impl CPU {
                     self.lsr_accumulator();
                 }
 
-                //todo: test for everything bellow
+                //todo: test for everything below
 
                 /* NOP read */
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c

--- a/code/ch6.1/src/main.rs
+++ b/code/ch6.1/src/main.rs
@@ -7,90 +7,18 @@ pub mod ppu;
 
 use bus::Bus;
 use cartridge::Rom;
-use cpu::Mem;
 use cpu::CPU;
 use trace::trace;
-// use rand::Rng;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
-use sdl2::EventPump;
 
 #[macro_use]
 extern crate lazy_static;
 
 #[macro_use]
 extern crate bitflags;
-
-fn color(byte: u8) -> Color {
-    match byte {
-        0 => sdl2::pixels::Color::BLACK,
-        1 => sdl2::pixels::Color::WHITE,
-        2 | 9 => sdl2::pixels::Color::GREY,
-        3 | 10 => sdl2::pixels::Color::RED,
-        4 | 11 => sdl2::pixels::Color::GREEN,
-        5 | 12 => sdl2::pixels::Color::BLUE,
-        6 | 13 => sdl2::pixels::Color::MAGENTA,
-        7 | 14 => sdl2::pixels::Color::YELLOW,
-        _ => sdl2::pixels::Color::CYAN,
-    }
-}
-
-fn read_screen_state(cpu: &mut CPU, frame: &mut [u8; 32 * 3 * 32]) -> bool {
-    let mut frame_idx = 0;
-    let mut update = false;
-    for i in 0x0200..0x600 {
-        let color_idx = cpu.mem_read(i as u16);
-        let (b1, b2, b3) = color(color_idx).rgb();
-        if frame[frame_idx] != b1 || frame[frame_idx + 1] != b2 || frame[frame_idx + 2] != b3 {
-            frame[frame_idx] = b1;
-            frame[frame_idx + 1] = b2;
-            frame[frame_idx + 2] = b3;
-            update = true;
-        }
-        frame_idx += 3;
-    }
-    update
-}
-
-fn handle_user_input(cpu: &mut CPU, event_pump: &mut EventPump) {
-    for event in event_pump.poll_iter() {
-        match event {
-            Event::Quit { .. }
-            | Event::KeyDown {
-                keycode: Some(Keycode::Escape),
-                ..
-            } => std::process::exit(0),
-            Event::KeyDown {
-                keycode: Some(Keycode::W),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x77);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::S),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x73);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::A),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x61);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::D),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x64);
-            }
-            _ => { /* do nothing */ }
-        }
-    }
-}
 
 fn main() {
     // init sdl2

--- a/code/ch6.1/src/main.rs
+++ b/code/ch6.1/src/main.rs
@@ -17,7 +17,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-// use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;
@@ -138,6 +137,6 @@ fn main() {
         //     canvas.present();
         // }
 
-        // ::std::thread::sleep(std::time::Duration::new(0, 70_000));
+        // std::thread::sleep(std::time::Duration::new(0, 70_000));
     });
 }

--- a/code/ch6.1/src/ppu/mod.rs
+++ b/code/ch6.1/src/ppu/mod.rs
@@ -41,7 +41,7 @@ pub trait PPU {
 
 impl NesPPU {
     pub fn new_empty_rom() -> Self {
-        NesPPU::new(vec![0; 2048], Mirroring::HORIZONTAL)
+        NesPPU::new(vec![0; 2048], Mirroring::Horizontal)
     }
 
     pub fn new(chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
@@ -73,10 +73,10 @@ impl NesPPU {
         let vram_index = mirrored_vram - 0x2000; // to vram vector
         let name_table = vram_index / 0x400;
         match (&self.mirroring, name_table) {
-            (Mirroring::VERTICAL, 2) | (Mirroring::VERTICAL, 3) => vram_index - 0x800,
-            (Mirroring::HORIZONTAL, 2) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 1) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 3) => vram_index - 0x800,
+            (Mirroring::Vertical, 2) | (Mirroring::Vertical, 3) => vram_index - 0x800,
+            (Mirroring::Horizontal, 2) => vram_index - 0x400,
+            (Mirroring::Horizontal, 1) => vram_index - 0x400,
+            (Mirroring::Horizontal, 3) => vram_index - 0x800,
             _ => vram_index,
         }
     }
@@ -282,7 +282,7 @@ pub mod test {
     //   [0x2800 a ] [0x2C00 b ]
     #[test]
     fn test_vram_vertical_mirror() {
-        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::VERTICAL);
+        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::Vertical);
 
         ppu.write_to_ppu_addr(0x20);
         ppu.write_to_ppu_addr(0x05);

--- a/code/ch6.2/src/cartridge.rs
+++ b/code/ch6.2/src/cartridge.rs
@@ -4,9 +4,9 @@ const CHR_ROM_PAGE_SIZE: usize = 8192;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Mirroring {
-    VERTICAL,
-    HORIZONTAL,
-    FOUR_SCREEN,
+    Vertical,
+    Horizontal,
+    FourScreen,
 }
 
 pub struct Rom {
@@ -32,9 +32,9 @@ impl Rom {
         let four_screen = raw[6] & 0b1000 != 0;
         let vertical_mirroring = raw[6] & 0b1 != 0;
         let screen_mirroring = match (four_screen, vertical_mirroring) {
-            (true, _) => Mirroring::FOUR_SCREEN,
-            (false, true) => Mirroring::VERTICAL,
-            (false, false) => Mirroring::HORIZONTAL,
+            (true, _) => Mirroring::FourScreen,
+            (false, true) => Mirroring::Vertical,
+            (false, false) => Mirroring::Horizontal,
         };
 
         let prg_rom_size = raw[4] as usize * PRG_ROM_PAGE_SIZE;
@@ -119,7 +119,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]
@@ -153,7 +153,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]

--- a/code/ch6.2/src/cpu.rs
+++ b/code/ch6.2/src/cpu.rs
@@ -1059,7 +1059,7 @@ impl CPU {
                     self.lsr_accumulator();
                 }
 
-                //todo: test for everything bellow
+                //todo: test for everything below
 
                 /* NOP read */
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c

--- a/code/ch6.2/src/cpu.rs
+++ b/code/ch6.2/src/cpu.rs
@@ -1065,7 +1065,7 @@ impl CPU {
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c
                 | 0x3c | 0x5c | 0x7c | 0xdc | 0xfc => {
                     let (addr, page_cross) = self.get_operand_address(&opcode.mode);
-                    let data = self.mem_read(addr);
+                    let _data = self.mem_read(addr);
                     if page_cross {
                         self.bus.tick(1);
                     }

--- a/code/ch6.2/src/cpu.rs
+++ b/code/ch6.2/src/cpu.rs
@@ -1178,8 +1178,6 @@ impl CPU {
                     let data = self.register_y & ((mem_address >> 8) as u8 + 1);
                     self.mem_write(mem_address, data)
                 }
-
-                _ => todo!(),
             }
 
             self.bus.tick(opcode.cycles);

--- a/code/ch6.2/src/main.rs
+++ b/code/ch6.2/src/main.rs
@@ -7,90 +7,18 @@ pub mod ppu;
 
 use bus::Bus;
 use cartridge::Rom;
-use cpu::Mem;
 use cpu::CPU;
 use trace::trace;
-// use rand::Rng;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
-use sdl2::EventPump;
 
 #[macro_use]
 extern crate lazy_static;
 
 #[macro_use]
 extern crate bitflags;
-
-fn color(byte: u8) -> Color {
-    match byte {
-        0 => sdl2::pixels::Color::BLACK,
-        1 => sdl2::pixels::Color::WHITE,
-        2 | 9 => sdl2::pixels::Color::GREY,
-        3 | 10 => sdl2::pixels::Color::RED,
-        4 | 11 => sdl2::pixels::Color::GREEN,
-        5 | 12 => sdl2::pixels::Color::BLUE,
-        6 | 13 => sdl2::pixels::Color::MAGENTA,
-        7 | 14 => sdl2::pixels::Color::YELLOW,
-        _ => sdl2::pixels::Color::CYAN,
-    }
-}
-
-fn read_screen_state(cpu: &mut CPU, frame: &mut [u8; 32 * 3 * 32]) -> bool {
-    let mut frame_idx = 0;
-    let mut update = false;
-    for i in 0x0200..0x600 {
-        let color_idx = cpu.mem_read(i as u16);
-        let (b1, b2, b3) = color(color_idx).rgb();
-        if frame[frame_idx] != b1 || frame[frame_idx + 1] != b2 || frame[frame_idx + 2] != b3 {
-            frame[frame_idx] = b1;
-            frame[frame_idx + 1] = b2;
-            frame[frame_idx + 2] = b3;
-            update = true;
-        }
-        frame_idx += 3;
-    }
-    update
-}
-
-fn handle_user_input(cpu: &mut CPU, event_pump: &mut EventPump) {
-    for event in event_pump.poll_iter() {
-        match event {
-            Event::Quit { .. }
-            | Event::KeyDown {
-                keycode: Some(Keycode::Escape),
-                ..
-            } => std::process::exit(0),
-            Event::KeyDown {
-                keycode: Some(Keycode::W),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x77);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::S),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x73);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::A),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x61);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::D),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x64);
-            }
-            _ => { /* do nothing */ }
-        }
-    }
-}
 
 fn main() {
     // init sdl2

--- a/code/ch6.2/src/main.rs
+++ b/code/ch6.2/src/main.rs
@@ -17,7 +17,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-// use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;
@@ -138,6 +137,6 @@ fn main() {
         //     canvas.present();
         // }
 
-        // ::std::thread::sleep(std::time::Duration::new(0, 70_000));
+        // std::thread::sleep(std::time::Duration::new(0, 70_000));
     });
 }

--- a/code/ch6.2/src/ppu/mod.rs
+++ b/code/ch6.2/src/ppu/mod.rs
@@ -46,7 +46,7 @@ pub trait PPU {
 
 impl NesPPU {
     pub fn new_empty_rom() -> Self {
-        NesPPU::new(vec![0; 2048], Mirroring::HORIZONTAL)
+        NesPPU::new(vec![0; 2048], Mirroring::Horizontal)
     }
 
     pub fn new(chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
@@ -82,10 +82,10 @@ impl NesPPU {
         let vram_index = mirrored_vram - 0x2000; // to vram vector
         let name_table = vram_index / 0x400;
         match (&self.mirroring, name_table) {
-            (Mirroring::VERTICAL, 2) | (Mirroring::VERTICAL, 3) => vram_index - 0x800,
-            (Mirroring::HORIZONTAL, 2) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 1) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 3) => vram_index - 0x800,
+            (Mirroring::Vertical, 2) | (Mirroring::Vertical, 3) => vram_index - 0x800,
+            (Mirroring::Horizontal, 2) => vram_index - 0x400,
+            (Mirroring::Horizontal, 1) => vram_index - 0x400,
+            (Mirroring::Horizontal, 3) => vram_index - 0x800,
             _ => vram_index,
         }
     }
@@ -325,7 +325,7 @@ pub mod test {
     //   [0x2800 a ] [0x2C00 b ]
     #[test]
     fn test_vram_vertical_mirror() {
-        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::VERTICAL);
+        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::Vertical);
 
         ppu.write_to_ppu_addr(0x20);
         ppu.write_to_ppu_addr(0x05);

--- a/code/ch6.3/src/cartridge.rs
+++ b/code/ch6.3/src/cartridge.rs
@@ -4,9 +4,9 @@ const CHR_ROM_PAGE_SIZE: usize = 8192;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Mirroring {
-    VERTICAL,
-    HORIZONTAL,
-    FOUR_SCREEN,
+    Vertical,
+    Horizontal,
+    FourScreen,
 }
 
 pub struct Rom {
@@ -32,9 +32,9 @@ impl Rom {
         let four_screen = raw[6] & 0b1000 != 0;
         let vertical_mirroring = raw[6] & 0b1 != 0;
         let screen_mirroring = match (four_screen, vertical_mirroring) {
-            (true, _) => Mirroring::FOUR_SCREEN,
-            (false, true) => Mirroring::VERTICAL,
-            (false, false) => Mirroring::HORIZONTAL,
+            (true, _) => Mirroring::FourScreen,
+            (false, true) => Mirroring::Vertical,
+            (false, false) => Mirroring::Horizontal,
         };
 
         let prg_rom_size = raw[4] as usize * PRG_ROM_PAGE_SIZE;
@@ -119,7 +119,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]
@@ -153,7 +153,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]

--- a/code/ch6.3/src/cpu.rs
+++ b/code/ch6.3/src/cpu.rs
@@ -1059,7 +1059,7 @@ impl CPU {
                     self.lsr_accumulator();
                 }
 
-                //todo: test for everything bellow
+                //todo: test for everything below
 
                 /* NOP read */
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c

--- a/code/ch6.3/src/cpu.rs
+++ b/code/ch6.3/src/cpu.rs
@@ -1065,7 +1065,7 @@ impl CPU {
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c
                 | 0x3c | 0x5c | 0x7c | 0xdc | 0xfc => {
                     let (addr, page_cross) = self.get_operand_address(&opcode.mode);
-                    let data = self.mem_read(addr);
+                    let _data = self.mem_read(addr);
                     if page_cross {
                         self.bus.tick(1);
                     }

--- a/code/ch6.3/src/cpu.rs
+++ b/code/ch6.3/src/cpu.rs
@@ -1178,8 +1178,6 @@ impl CPU {
                     let data = self.register_y & ((mem_address >> 8) as u8 + 1);
                     self.mem_write(mem_address, data)
                 }
-
-                _ => todo!(),
             }
 
             self.bus.tick(opcode.cycles);

--- a/code/ch6.3/src/main.rs
+++ b/code/ch6.3/src/main.rs
@@ -20,7 +20,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-// use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;
@@ -140,6 +139,6 @@ fn main() {
         //     canvas.present();
         // }
 
-        // ::std::thread::sleep(std::time::Duration::new(0, 70_000));
+        // std::thread::sleep(std::time::Duration::new(0, 70_000));
     });
 }

--- a/code/ch6.3/src/main.rs
+++ b/code/ch6.3/src/main.rs
@@ -8,93 +8,19 @@ pub mod render;
 
 use bus::Bus;
 use cartridge::Rom;
-use cpu::Mem;
 use cpu::CPU;
 use trace::trace;
 use render::frame::Frame;
-use render::palette;
-// use rand::Rng;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
-use sdl2::EventPump;
 
 #[macro_use]
 extern crate lazy_static;
 
 #[macro_use]
 extern crate bitflags;
-
-fn color(byte: u8) -> Color {
-    match byte {
-        0 => sdl2::pixels::Color::BLACK,
-        1 => sdl2::pixels::Color::WHITE,
-        2 | 9 => sdl2::pixels::Color::GREY,
-        3 | 10 => sdl2::pixels::Color::RED,
-        4 | 11 => sdl2::pixels::Color::GREEN,
-        5 | 12 => sdl2::pixels::Color::BLUE,
-        6 | 13 => sdl2::pixels::Color::MAGENTA,
-        7 | 14 => sdl2::pixels::Color::YELLOW,
-        _ => sdl2::pixels::Color::CYAN,
-    }
-}
-
-fn read_screen_state(cpu: &mut CPU, frame: &mut [u8; 32 * 3 * 32]) -> bool {
-    let mut frame_idx = 0;
-    let mut update = false;
-    for i in 0x0200..0x600 {
-        let color_idx = cpu.mem_read(i as u16);
-        let (b1, b2, b3) = color(color_idx).rgb();
-        if frame[frame_idx] != b1 || frame[frame_idx + 1] != b2 || frame[frame_idx + 2] != b3 {
-            frame[frame_idx] = b1;
-            frame[frame_idx + 1] = b2;
-            frame[frame_idx + 2] = b3;
-            update = true;
-        }
-        frame_idx += 3;
-    }
-    update
-}
-
-fn handle_user_input(cpu: &mut CPU, event_pump: &mut EventPump) {
-    for event in event_pump.poll_iter() {
-        match event {
-            Event::Quit { .. }
-            | Event::KeyDown {
-                keycode: Some(Keycode::Escape),
-                ..
-            } => std::process::exit(0),
-            Event::KeyDown {
-                keycode: Some(Keycode::W),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x77);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::S),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x73);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::A),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x61);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::D),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x64);
-            }
-            _ => { /* do nothing */ }
-        }
-    }
-}
-
 
 fn main() {
     // init sdl2

--- a/code/ch6.3/src/ppu/mod.rs
+++ b/code/ch6.3/src/ppu/mod.rs
@@ -46,7 +46,7 @@ pub trait PPU {
 
 impl NesPPU {
     pub fn new_empty_rom() -> Self {
-        NesPPU::new(vec![0; 2048], Mirroring::HORIZONTAL)
+        NesPPU::new(vec![0; 2048], Mirroring::Horizontal)
     }
 
     pub fn new(chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
@@ -82,10 +82,10 @@ impl NesPPU {
         let vram_index = mirrored_vram - 0x2000; // to vram vector
         let name_table = vram_index / 0x400;
         match (&self.mirroring, name_table) {
-            (Mirroring::VERTICAL, 2) | (Mirroring::VERTICAL, 3) => vram_index - 0x800,
-            (Mirroring::HORIZONTAL, 2) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 1) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 3) => vram_index - 0x800,
+            (Mirroring::Vertical, 2) | (Mirroring::Vertical, 3) => vram_index - 0x800,
+            (Mirroring::Horizontal, 2) => vram_index - 0x400,
+            (Mirroring::Horizontal, 1) => vram_index - 0x400,
+            (Mirroring::Horizontal, 3) => vram_index - 0x800,
             _ => vram_index,
         }
     }
@@ -325,7 +325,7 @@ pub mod test {
     //   [0x2800 a ] [0x2C00 b ]
     #[test]
     fn test_vram_vertical_mirror() {
-        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::VERTICAL);
+        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::Vertical);
 
         ppu.write_to_ppu_addr(0x20);
         ppu.write_to_ppu_addr(0x05);

--- a/code/ch6.3/src/tiles_viewer.rs
+++ b/code/ch6.3/src/tiles_viewer.rs
@@ -13,7 +13,6 @@ use cpu::CPU;
 use trace::trace;
 use render::frame::Frame;
 use render::palette;
-// use rand::Rng;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;

--- a/code/ch6.3/src/tiles_viewer.rs
+++ b/code/ch6.3/src/tiles_viewer.rs
@@ -20,7 +20,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-// use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;

--- a/code/ch6.4/src/cartridge.rs
+++ b/code/ch6.4/src/cartridge.rs
@@ -4,9 +4,9 @@ const CHR_ROM_PAGE_SIZE: usize = 8192;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Mirroring {
-    VERTICAL,
-    HORIZONTAL,
-    FOUR_SCREEN,
+    Vertical,
+    Horizontal,
+    FourScreen,
 }
 
 pub struct Rom {
@@ -32,9 +32,9 @@ impl Rom {
         let four_screen = raw[6] & 0b1000 != 0;
         let vertical_mirroring = raw[6] & 0b1 != 0;
         let screen_mirroring = match (four_screen, vertical_mirroring) {
-            (true, _) => Mirroring::FOUR_SCREEN,
-            (false, true) => Mirroring::VERTICAL,
-            (false, false) => Mirroring::HORIZONTAL,
+            (true, _) => Mirroring::FourScreen,
+            (false, true) => Mirroring::Vertical,
+            (false, false) => Mirroring::Horizontal,
         };
 
         let prg_rom_size = raw[4] as usize * PRG_ROM_PAGE_SIZE;
@@ -119,7 +119,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]
@@ -153,7 +153,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]

--- a/code/ch6.4/src/cpu.rs
+++ b/code/ch6.4/src/cpu.rs
@@ -1059,7 +1059,7 @@ impl<'a> CPU<'a> {
                     self.lsr_accumulator();
                 }
 
-                //todo: test for everything bellow
+                //todo: test for everything below
 
                 /* NOP read */
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c

--- a/code/ch6.4/src/cpu.rs
+++ b/code/ch6.4/src/cpu.rs
@@ -1178,8 +1178,6 @@ impl<'a> CPU<'a> {
                     let data = self.register_y & ((mem_address >> 8) as u8 + 1);
                     self.mem_write(mem_address, data)
                 }
-
-                _ => todo!(),
             }
 
             self.bus.tick(opcode.cycles);

--- a/code/ch6.4/src/cpu.rs
+++ b/code/ch6.4/src/cpu.rs
@@ -1065,7 +1065,7 @@ impl<'a> CPU<'a> {
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c
                 | 0x3c | 0x5c | 0x7c | 0xdc | 0xfc => {
                     let (addr, page_cross) = self.get_operand_address(&opcode.mode);
-                    let data = self.mem_read(addr);
+                    let _data = self.mem_read(addr);
                     if page_cross {
                         self.bus.tick(1);
                     }

--- a/code/ch6.4/src/main.rs
+++ b/code/ch6.4/src/main.rs
@@ -8,94 +8,20 @@ pub mod render;
 
 use bus::Bus;
 use cartridge::Rom;
-use cpu::Mem;
 use cpu::CPU;
-use trace::trace;
+// use trace::trace;
 use render::frame::Frame;
-use render::palette;
 use ppu::NesPPU;
-// use rand::Rng;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
-use sdl2::EventPump;
 
 #[macro_use]
 extern crate lazy_static;
 
 #[macro_use]
 extern crate bitflags;
-
-fn color(byte: u8) -> Color {
-    match byte {
-        0 => sdl2::pixels::Color::BLACK,
-        1 => sdl2::pixels::Color::WHITE,
-        2 | 9 => sdl2::pixels::Color::GREY,
-        3 | 10 => sdl2::pixels::Color::RED,
-        4 | 11 => sdl2::pixels::Color::GREEN,
-        5 | 12 => sdl2::pixels::Color::BLUE,
-        6 | 13 => sdl2::pixels::Color::MAGENTA,
-        7 | 14 => sdl2::pixels::Color::YELLOW,
-        _ => sdl2::pixels::Color::CYAN,
-    }
-}
-
-fn read_screen_state(cpu: &mut CPU, frame: &mut [u8; 32 * 3 * 32]) -> bool {
-    let mut frame_idx = 0;
-    let mut update = false;
-    for i in 0x0200..0x600 {
-        let color_idx = cpu.mem_read(i as u16);
-        let (b1, b2, b3) = color(color_idx).rgb();
-        if frame[frame_idx] != b1 || frame[frame_idx + 1] != b2 || frame[frame_idx + 2] != b3 {
-            frame[frame_idx] = b1;
-            frame[frame_idx + 1] = b2;
-            frame[frame_idx + 2] = b3;
-            update = true;
-        }
-        frame_idx += 3;
-    }
-    update
-}
-
-fn handle_user_input(cpu: &mut CPU, event_pump: &mut EventPump) {
-    for event in event_pump.poll_iter() {
-        match event {
-            Event::Quit { .. }
-            | Event::KeyDown {
-                keycode: Some(Keycode::Escape),
-                ..
-            } => std::process::exit(0),
-            Event::KeyDown {
-                keycode: Some(Keycode::W),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x77);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::S),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x73);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::A),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x61);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::D),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x64);
-            }
-            _ => { /* do nothing */ }
-        }
-    }
-}
-
 
 fn main() {
     // init sdl2

--- a/code/ch6.4/src/main.rs
+++ b/code/ch6.4/src/main.rs
@@ -21,7 +21,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-// use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;

--- a/code/ch6.4/src/ppu/mod.rs
+++ b/code/ch6.4/src/ppu/mod.rs
@@ -46,7 +46,7 @@ pub trait PPU {
 
 impl NesPPU {
     pub fn new_empty_rom() -> Self {
-        NesPPU::new(vec![0; 2048], Mirroring::HORIZONTAL)
+        NesPPU::new(vec![0; 2048], Mirroring::Horizontal)
     }
 
     pub fn new(chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
@@ -82,10 +82,10 @@ impl NesPPU {
         let vram_index = mirrored_vram - 0x2000; // to vram vector
         let name_table = vram_index / 0x400;
         match (&self.mirroring, name_table) {
-            (Mirroring::VERTICAL, 2) | (Mirroring::VERTICAL, 3) => vram_index - 0x800,
-            (Mirroring::HORIZONTAL, 2) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 1) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 3) => vram_index - 0x800,
+            (Mirroring::Vertical, 2) | (Mirroring::Vertical, 3) => vram_index - 0x800,
+            (Mirroring::Horizontal, 2) => vram_index - 0x400,
+            (Mirroring::Horizontal, 1) => vram_index - 0x400,
+            (Mirroring::Horizontal, 3) => vram_index - 0x800,
             _ => vram_index,
         }
     }
@@ -324,7 +324,7 @@ pub mod test {
     //   [0x2800 a ] [0x2C00 b ]
     #[test]
     fn test_vram_vertical_mirror() {
-        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::VERTICAL);
+        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::Vertical);
 
         ppu.write_to_ppu_addr(0x20);
         ppu.write_to_ppu_addr(0x05);

--- a/code/ch6.4/src/tiles_viewer.rs
+++ b/code/ch6.4/src/tiles_viewer.rs
@@ -13,7 +13,6 @@ use cpu::CPU;
 use trace::trace;
 use render::frame::Frame;
 use render::palette;
-// use rand::Rng;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;

--- a/code/ch6.4/src/tiles_viewer.rs
+++ b/code/ch6.4/src/tiles_viewer.rs
@@ -20,7 +20,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-// use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;

--- a/code/ch7/src/cartridge.rs
+++ b/code/ch7/src/cartridge.rs
@@ -4,9 +4,9 @@ const CHR_ROM_PAGE_SIZE: usize = 8192;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Mirroring {
-    VERTICAL,
-    HORIZONTAL,
-    FOUR_SCREEN,
+    Vertical,
+    Horizontal,
+    FourScreen,
 }
 
 pub struct Rom {
@@ -32,9 +32,9 @@ impl Rom {
         let four_screen = raw[6] & 0b1000 != 0;
         let vertical_mirroring = raw[6] & 0b1 != 0;
         let screen_mirroring = match (four_screen, vertical_mirroring) {
-            (true, _) => Mirroring::FOUR_SCREEN,
-            (false, true) => Mirroring::VERTICAL,
-            (false, false) => Mirroring::HORIZONTAL,
+            (true, _) => Mirroring::FourScreen,
+            (false, true) => Mirroring::Vertical,
+            (false, false) => Mirroring::Horizontal,
         };
 
         let prg_rom_size = raw[4] as usize * PRG_ROM_PAGE_SIZE;
@@ -119,7 +119,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]
@@ -153,7 +153,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]

--- a/code/ch7/src/cpu.rs
+++ b/code/ch7/src/cpu.rs
@@ -1061,7 +1061,7 @@ impl<'a> CPU<'a> {
                     self.lsr_accumulator();
                 }
 
-                //todo: test for everything bellow
+                //todo: test for everything below
 
                 /* NOP read */
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c

--- a/code/ch7/src/cpu.rs
+++ b/code/ch7/src/cpu.rs
@@ -1067,7 +1067,7 @@ impl<'a> CPU<'a> {
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c
                 | 0x3c | 0x5c | 0x7c | 0xdc | 0xfc => {
                     let (addr, page_cross) = self.get_operand_address(&opcode.mode);
-                    let data = self.mem_read(addr);
+                    let _data = self.mem_read(addr);
                     if page_cross {
                         self.bus.tick(1);
                     }

--- a/code/ch7/src/cpu.rs
+++ b/code/ch7/src/cpu.rs
@@ -1180,8 +1180,6 @@ impl<'a> CPU<'a> {
                     let data = self.register_y & ((mem_address >> 8) as u8 + 1);
                     self.mem_write(mem_address, data)
                 }
-
-                _ => todo!(),
             }
 
             self.bus.tick(opcode.cycles);

--- a/code/ch7/src/main.rs
+++ b/code/ch7/src/main.rs
@@ -21,7 +21,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-// use std::time::Duration;
 use std::collections::HashMap;
 
 #[macro_use]

--- a/code/ch7/src/main.rs
+++ b/code/ch7/src/main.rs
@@ -9,18 +9,14 @@ pub mod trace;
 
 use bus::Bus;
 use cartridge::Rom;
-use cpu::Mem;
 use cpu::CPU;
 use ppu::NesPPU;
 use render::frame::Frame;
-use render::palette;
-use trace::trace;
+// use trace::trace;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
-use sdl2::EventPump;
 use std::collections::HashMap;
 
 #[macro_use]
@@ -28,74 +24,6 @@ extern crate lazy_static;
 
 #[macro_use]
 extern crate bitflags;
-
-fn color(byte: u8) -> Color {
-    match byte {
-        0 => sdl2::pixels::Color::BLACK,
-        1 => sdl2::pixels::Color::WHITE,
-        2 | 9 => sdl2::pixels::Color::GREY,
-        3 | 10 => sdl2::pixels::Color::RED,
-        4 | 11 => sdl2::pixels::Color::GREEN,
-        5 | 12 => sdl2::pixels::Color::BLUE,
-        6 | 13 => sdl2::pixels::Color::MAGENTA,
-        7 | 14 => sdl2::pixels::Color::YELLOW,
-        _ => sdl2::pixels::Color::CYAN,
-    }
-}
-
-fn read_screen_state(cpu: &mut CPU, frame: &mut [u8; 32 * 3 * 32]) -> bool {
-    let mut frame_idx = 0;
-    let mut update = false;
-    for i in 0x0200..0x600 {
-        let color_idx = cpu.mem_read(i as u16);
-        let (b1, b2, b3) = color(color_idx).rgb();
-        if frame[frame_idx] != b1 || frame[frame_idx + 1] != b2 || frame[frame_idx + 2] != b3 {
-            frame[frame_idx] = b1;
-            frame[frame_idx + 1] = b2;
-            frame[frame_idx + 2] = b3;
-            update = true;
-        }
-        frame_idx += 3;
-    }
-    update
-}
-
-fn handle_user_input(cpu: &mut CPU, event_pump: &mut EventPump) {
-    for event in event_pump.poll_iter() {
-        match event {
-            Event::Quit { .. }
-            | Event::KeyDown {
-                keycode: Some(Keycode::Escape),
-                ..
-            } => std::process::exit(0),
-            Event::KeyDown {
-                keycode: Some(Keycode::W),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x77);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::S),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x73);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::A),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x61);
-            }
-            Event::KeyDown {
-                keycode: Some(Keycode::D),
-                ..
-            } => {
-                cpu.mem_write(0xff, 0x64);
-            }
-            _ => { /* do nothing */ }
-        }
-    }
-}
 
 fn main() {
     // init sdl2

--- a/code/ch7/src/ppu/mod.rs
+++ b/code/ch7/src/ppu/mod.rs
@@ -44,7 +44,7 @@ pub trait PPU {
 
 impl NesPPU {
     pub fn new_empty_rom() -> Self {
-        NesPPU::new(vec![0; 2048], Mirroring::HORIZONTAL)
+        NesPPU::new(vec![0; 2048], Mirroring::Horizontal)
     }
 
     pub fn new(chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
@@ -80,10 +80,10 @@ impl NesPPU {
         let vram_index = mirrored_vram - 0x2000; // to vram vector
         let name_table = vram_index / 0x400;
         match (&self.mirroring, name_table) {
-            (Mirroring::VERTICAL, 2) | (Mirroring::VERTICAL, 3) => vram_index - 0x800,
-            (Mirroring::HORIZONTAL, 2) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 1) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 3) => vram_index - 0x800,
+            (Mirroring::Vertical, 2) | (Mirroring::Vertical, 3) => vram_index - 0x800,
+            (Mirroring::Horizontal, 2) => vram_index - 0x400,
+            (Mirroring::Horizontal, 1) => vram_index - 0x400,
+            (Mirroring::Horizontal, 3) => vram_index - 0x800,
             _ => vram_index,
         }
     }
@@ -317,7 +317,7 @@ pub mod test {
     //   [0x2800 a ] [0x2C00 b ]
     #[test]
     fn test_vram_vertical_mirror() {
-        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::VERTICAL);
+        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::Vertical);
 
         ppu.write_to_ppu_addr(0x20);
         ppu.write_to_ppu_addr(0x05);

--- a/code/ch7/src/tiles_viewer.rs
+++ b/code/ch7/src/tiles_viewer.rs
@@ -13,7 +13,6 @@ use cpu::CPU;
 use trace::trace;
 use render::frame::Frame;
 use render::palette;
-// use rand::Rng;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;

--- a/code/ch7/src/tiles_viewer.rs
+++ b/code/ch7/src/tiles_viewer.rs
@@ -20,7 +20,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-// use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;

--- a/code/ch8/src/cartridge.rs
+++ b/code/ch8/src/cartridge.rs
@@ -4,9 +4,9 @@ const CHR_ROM_PAGE_SIZE: usize = 8192;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Mirroring {
-    VERTICAL,
-    HORIZONTAL,
-    FOUR_SCREEN,
+    Vertical,
+    Horizontal,
+    FourScreen,
 }
 
 pub struct Rom {
@@ -32,9 +32,9 @@ impl Rom {
         let four_screen = raw[6] & 0b1000 != 0;
         let vertical_mirroring = raw[6] & 0b1 != 0;
         let screen_mirroring = match (four_screen, vertical_mirroring) {
-            (true, _) => Mirroring::FOUR_SCREEN,
-            (false, true) => Mirroring::VERTICAL,
-            (false, false) => Mirroring::HORIZONTAL,
+            (true, _) => Mirroring::FourScreen,
+            (false, true) => Mirroring::Vertical,
+            (false, false) => Mirroring::Horizontal,
         };
 
         let prg_rom_size = raw[4] as usize * PRG_ROM_PAGE_SIZE;
@@ -119,7 +119,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]
@@ -153,7 +153,7 @@ pub mod test {
         assert_eq!(rom.chr_rom, vec!(2; 1 * CHR_ROM_PAGE_SIZE));
         assert_eq!(rom.prg_rom, vec!(1; 2 * PRG_ROM_PAGE_SIZE));
         assert_eq!(rom.mapper, 3);
-        assert_eq!(rom.screen_mirroring, Mirroring::VERTICAL);
+        assert_eq!(rom.screen_mirroring, Mirroring::Vertical);
     }
 
     #[test]

--- a/code/ch8/src/cpu.rs
+++ b/code/ch8/src/cpu.rs
@@ -1083,7 +1083,7 @@ impl<'a> CPU<'a> {
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c
                 | 0x3c | 0x5c | 0x7c | 0xdc | 0xfc => {
                     let (addr, page_cross) = self.get_operand_address(&opcode.mode);
-                    let data = self.mem_read(addr);
+                    let _data = self.mem_read(addr);
                     if page_cross {
                         self.bus.tick(1);
                     }

--- a/code/ch8/src/cpu.rs
+++ b/code/ch8/src/cpu.rs
@@ -1077,7 +1077,7 @@ impl<'a> CPU<'a> {
                     self.lsr_accumulator();
                 }
 
-                //todo: test for everything bellow
+                //todo: test for everything below
 
                 /* NOP read */
                 0x04 | 0x44 | 0x64 | 0x14 | 0x34 | 0x54 | 0x74 | 0xd4 | 0xf4 | 0x0c | 0x1c

--- a/code/ch8/src/cpu.rs
+++ b/code/ch8/src/cpu.rs
@@ -1196,8 +1196,6 @@ impl<'a> CPU<'a> {
                     let data = self.register_y & ((mem_address >> 8) as u8 + 1);
                     self.mem_write(mem_address, data)
                 }
-
-                _ => todo!(),
             }
 
             self.bus.tick(opcode.cycles);

--- a/code/ch8/src/main.rs
+++ b/code/ch8/src/main.rs
@@ -21,7 +21,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-// use std::time::Duration;
 use std::collections::HashMap;
 
 #[macro_use]

--- a/code/ch8/src/main.rs
+++ b/code/ch8/src/main.rs
@@ -9,18 +9,14 @@ pub mod trace;
 
 use bus::Bus;
 use cartridge::Rom;
-use cpu::Mem;
 use cpu::CPU;
 use ppu::NesPPU;
 use render::frame::Frame;
-use render::palette;
-use trace::trace;
+// use trace::trace;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
-use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
-use sdl2::EventPump;
 use std::collections::HashMap;
 
 #[macro_use]
@@ -101,8 +97,10 @@ fn main() {
 
     let mut cpu = CPU::new(bus);
     cpu.reset();
-    // cpu.run();
+    cpu.run();
+    /*
     cpu.run_with_callback(|cpu| {
-        // println!("{}", trace(cpu));
+        println!("{}", trace(cpu));
     });
+    */
 }

--- a/code/ch8/src/ppu/mod.rs
+++ b/code/ch8/src/ppu/mod.rs
@@ -44,7 +44,7 @@ pub trait PPU {
 
 impl NesPPU {
     pub fn new_empty_rom() -> Self {
-        NesPPU::new(vec![0; 2048], Mirroring::HORIZONTAL)
+        NesPPU::new(vec![0; 2048], Mirroring::Horizontal)
     }
 
     pub fn new(chr_rom: Vec<u8>, mirroring: Mirroring) -> Self {
@@ -80,10 +80,10 @@ impl NesPPU {
         let vram_index = mirrored_vram - 0x2000; // to vram vector
         let name_table = vram_index / 0x400;
         match (&self.mirroring, name_table) {
-            (Mirroring::VERTICAL, 2) | (Mirroring::VERTICAL, 3) => vram_index - 0x800,
-            (Mirroring::HORIZONTAL, 2) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 1) => vram_index - 0x400,
-            (Mirroring::HORIZONTAL, 3) => vram_index - 0x800,
+            (Mirroring::Vertical, 2) | (Mirroring::Vertical, 3) => vram_index - 0x800,
+            (Mirroring::Horizontal, 2) => vram_index - 0x400,
+            (Mirroring::Horizontal, 1) => vram_index - 0x400,
+            (Mirroring::Horizontal, 3) => vram_index - 0x800,
             _ => vram_index,
         }
     }
@@ -328,7 +328,7 @@ pub mod test {
     //   [0x2800 a ] [0x2C00 b ]
     #[test]
     fn test_vram_vertical_mirror() {
-        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::VERTICAL);
+        let mut ppu = NesPPU::new(vec![0; 2048], Mirroring::Vertical);
 
         ppu.write_to_ppu_addr(0x20);
         ppu.write_to_ppu_addr(0x05);

--- a/code/ch8/src/render/mod.rs
+++ b/code/ch8/src/render/mod.rs
@@ -99,10 +99,10 @@ pub fn render(ppu: &NesPPU, frame: &mut Frame) {
     let scroll_y = (ppu.scroll.scroll_y) as usize;
 
     let (main_nametable, second_nametable) = match (&ppu.mirroring, ppu.ctrl.nametable_addr()) {
-        (Mirroring::VERTICAL, 0x2000) | (Mirroring::VERTICAL, 0x2800) | (Mirroring::HORIZONTAL, 0x2000) | (Mirroring::HORIZONTAL, 0x2400) => {
+        (Mirroring::Vertical, 0x2000) | (Mirroring::Vertical, 0x2800) | (Mirroring::Horizontal, 0x2000) | (Mirroring::Horizontal, 0x2400) => {
             (&ppu.vram[0..0x400], &ppu.vram[0x400..0x800])
         }
-        (Mirroring::VERTICAL, 0x2400) | (Mirroring::VERTICAL, 0x2C00) | (Mirroring::HORIZONTAL, 0x2800) | (Mirroring::HORIZONTAL, 0x2C00) => {
+        (Mirroring::Vertical, 0x2400) | (Mirroring::Vertical, 0x2C00) | (Mirroring::Horizontal, 0x2800) | (Mirroring::Horizontal, 0x2C00) => {
             ( &ppu.vram[0x400..0x800], &ppu.vram[0..0x400])
         }
         (_,_) => {

--- a/code/ch8/src/tiles_viewer.rs
+++ b/code/ch8/src/tiles_viewer.rs
@@ -13,7 +13,6 @@ use cpu::CPU;
 use trace::trace;
 use render::frame::Frame;
 use render::palette;
-// use rand::Rng;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;

--- a/code/ch8/src/tiles_viewer.rs
+++ b/code/ch8/src/tiles_viewer.rs
@@ -20,7 +20,6 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
-// use std::time::Duration;
 
 #[macro_use]
 extern crate lazy_static;

--- a/code/testAll
+++ b/code/testAll
@@ -1,6 +1,7 @@
 #for f in $(find . -name Cargo.toml -printf '%h\n' | sort -u); do
 for f in $(find . -name *.toml -print0 | xargs -0 -n1 dirname | sort --unique); do
   pushd $f > /dev/null;
+  echo Testing: $f
   cargo test;
   popd > /dev/null;
 done

--- a/src/chapter_3_4.md
+++ b/src/chapter_3_4.md
@@ -284,7 +284,7 @@ fn main() {
            canvas.present();
        }
 
-       ::std::thread::sleep(std::time::Duration::new(0, 70_000));
+       std::thread::sleep(std::time::Duration::new(0, 70_000));
    });
 }
 ```

--- a/src/chapter_5.md
+++ b/src/chapter_5.md
@@ -54,9 +54,9 @@ Let's define cartridge Rom data structure:
 ```rust
 #[derive(Debug, PartialEq)]
 pub enum Mirroring {
-   VERTICAL,
-   HORIZONTAL,
-   FOUR_SCREEN,
+   Vertical,
+   Horizontal,
+   FourScreen,
 }
 
 pub struct Rom {
@@ -87,9 +87,9 @@ impl Rom {
        let four_screen = raw[6] & 0b1000 != 0;
        let vertical_mirroring = raw[6] & 0b1 != 0;
        let screen_mirroring = match (four_screen, vertical_mirroring) {
-           (true, _) => Mirroring::FOUR_SCREEN,
-           (false, true) => Mirroring::VERTICAL,
-           (false, false) => Mirroring::HORIZONTAL,
+           (true, _) => Mirroring::FourScreen,
+           (false, true) => Mirroring::Vertical,
+           (false, false) => Mirroring::Horizontal,
        };
 
        let prg_rom_size = raw[4] as usize * PRG_ROM_PAGE_SIZE;

--- a/src/chapter_6_1.md
+++ b/src/chapter_6_1.md
@@ -363,10 +363,10 @@ impl NesPPU {
        let vram_index = mirrored_vram - 0x2000; // to vram vector
        let name_table = vram_index / 0x400; // to the name table index
        match (&self.mirroring, name_table) {
-           (Mirroring::VERTICAL, 2) | (Mirroring::VERTICAL, 3) => vram_index - 0x800,
-           (Mirroring::HORIZONTAL, 2) => vram_index - 0x400,
-           (Mirroring::HORIZONTAL, 1) => vram_index - 0x400,
-           (Mirroring::HORIZONTAL, 3) => vram_index - 0x800,
+           (Mirroring::Vertical, 2) | (Mirroring::Vertical, 3) => vram_index - 0x800,
+           (Mirroring::Horizontal, 2) => vram_index - 0x400,
+           (Mirroring::Horizontal, 1) => vram_index - 0x400,
+           (Mirroring::Horizontal, 3) => vram_index - 0x800,
            _ => vram_index,
        }
    }

--- a/src/chapter_8.md
+++ b/src/chapter_8.md
@@ -190,10 +190,10 @@ pub fn render(ppu: &NesPPU, frame: &mut Frame) {
    let scroll_y = (ppu.scroll.scroll_y) as usize;
 
    let (main_nametable, second_nametable) = match (&ppu.mirroring, ppu.ctrl.nametable_addr()) {
-       (Mirroring::VERTICAL, 0x2000) | (Mirroring::VERTICAL, 0x2800) => {
+       (Mirroring::Vertical, 0x2000) | (Mirroring::Vertical, 0x2800) => {
            (&ppu.vram[0..0x400], &ppu.vram[0x400..0x800])
        }
-       (Mirroring::VERTICAL, 0x2400) | (Mirroring::VERTICAL, 0x2C00) => {
+       (Mirroring::Vertical, 0x2400) | (Mirroring::Vertical, 0x2C00) => {
            ( &ppu.vram[0x400..0x800], &ppu.vram[0..0x400])
        }
        (_,_) => {


### PR DESCRIPTION
I've tried to fix the compiler warnings. There are still some to do, which may be impossible due to the incremental nature of the tutorial. i.e. You add something in one section and only add the call to it from the next section so we get an 'unused' warning, which is fine.

The main thing was the case of enums seems to be capitals now. I'm new to rust so assume that became a thing at some point.

I've tried to remove code (e.g. unused `use` import) when it's not coming back, but leave it in if it does in a later section. So, again we get 'unused import' warnings in the intervening sections.

I'm happy to tweak anything you don't like.