### PR TITLE
Update NESdev Wiki links from nesdev.com to nesdev.org

### DIFF
--- a/code/ch3.3/src/cpu.rs
+++ b/code/ch3.3/src/cpu.rs
@@ -2,7 +2,7 @@ use crate::opcodes;
 use std::collections::HashMap;
 
 bitflags! {
-    /// # Status Register (P) http://wiki.nesdev.com/w/index.php/Status_flags
+    /// # Status Register (P) https://www.nesdev.org/wiki/Status_flags
     ///
     ///  7 6 5 4 3 2 1 0
     ///  N V _ B D I Z C

--- a/code/ch3.3/src/cpu.rs
+++ b/code/ch3.3/src/cpu.rs
@@ -482,7 +482,7 @@ impl CPU {
     }
 
     fn php(&mut self) {
-        //http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior
+        //https://www.nesdev.org/wiki/Status_flags
         let mut flags = self.status.clone();
         flags.insert(CpuFlags::BREAK);
         flags.insert(CpuFlags::BREAK2);

--- a/code/ch3.4/src/cpu.rs
+++ b/code/ch3.4/src/cpu.rs
@@ -491,7 +491,7 @@ impl CPU {
     }
 
     fn php(&mut self) {
-        //http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior
+        //https://www.nesdev.org/wiki/Status_flags
         let mut flags = self.status.clone();
         flags.insert(CpuFlags::BREAK);
         flags.insert(CpuFlags::BREAK2);

--- a/code/ch3.4/src/cpu.rs
+++ b/code/ch3.4/src/cpu.rs
@@ -2,7 +2,7 @@ use crate::opcodes;
 use std::collections::HashMap;
 
 bitflags! {
-    /// # Status Register (P) http://wiki.nesdev.com/w/index.php/Status_flags
+    /// # Status Register (P) https://www.nesdev.org/wiki/Status_flags
     ///
     ///  7 6 5 4 3 2 1 0
     ///  N V _ B D I Z C

--- a/code/ch4/src/cpu.rs
+++ b/code/ch4/src/cpu.rs
@@ -501,7 +501,7 @@ impl CPU {
     }
 
     fn php(&mut self) {
-        //http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior
+        //https://www.nesdev.org/wiki/Status_flags
         let mut flags = self.status.clone();
         flags.insert(CpuFlags::BREAK);
         flags.insert(CpuFlags::BREAK2);

--- a/code/ch4/src/cpu.rs
+++ b/code/ch4/src/cpu.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::bus::Bus;
 
 bitflags! {
-    /// # Status Register (P) http://wiki.nesdev.com/w/index.php/Status_flags
+    /// # Status Register (P) https://www.nesdev.org/wiki/Status_flags
     ///
     ///  7 6 5 4 3 2 1 0
     ///  N V _ B D I Z C

--- a/code/ch5.1/src/cpu.rs
+++ b/code/ch5.1/src/cpu.rs
@@ -3,7 +3,7 @@ use crate::opcodes;
 use std::collections::HashMap;
 
 bitflags! {
-    /// # Status Register (P) http://wiki.nesdev.com/w/index.php/Status_flags
+    /// # Status Register (P) https://www.nesdev.org/wiki/Status_flags
     ///
     ///  7 6 5 4 3 2 1 0
     ///  N V _ B D I Z C

--- a/code/ch5.1/src/cpu.rs
+++ b/code/ch5.1/src/cpu.rs
@@ -517,7 +517,7 @@ impl CPU {
     }
 
     fn php(&mut self) {
-        //http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior
+        //https://www.nesdev.org/wiki/Status_flags
         let mut flags = self.status.clone();
         flags.insert(CpuFlags::BREAK);
         flags.insert(CpuFlags::BREAK2);

--- a/code/ch5/src/cpu.rs
+++ b/code/ch5/src/cpu.rs
@@ -3,7 +3,7 @@ use crate::opcodes;
 use std::collections::HashMap;
 
 bitflags! {
-    /// # Status Register (P) http://wiki.nesdev.com/w/index.php/Status_flags
+    /// # Status Register (P) https://www.nesdev.org/wiki/Status_flags
     ///
     ///  7 6 5 4 3 2 1 0
     ///  N V _ B D I Z C

--- a/code/ch5/src/cpu.rs
+++ b/code/ch5/src/cpu.rs
@@ -495,7 +495,7 @@ impl CPU {
     }
 
     fn php(&mut self) {
-        //http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior
+        //https://www.nesdev.org/wiki/Status_flags
         let mut flags = self.status.clone();
         flags.insert(CpuFlags::BREAK);
         flags.insert(CpuFlags::BREAK2);

--- a/code/ch6.1/src/cpu.rs
+++ b/code/ch6.1/src/cpu.rs
@@ -3,7 +3,7 @@ use crate::opcodes;
 use std::collections::HashMap;
 
 bitflags! {
-    /// # Status Register (P) http://wiki.nesdev.com/w/index.php/Status_flags
+    /// # Status Register (P) https://www.nesdev.org/wiki/Status_flags
     ///
     ///  7 6 5 4 3 2 1 0
     ///  N V _ B D I Z C

--- a/code/ch6.1/src/cpu.rs
+++ b/code/ch6.1/src/cpu.rs
@@ -517,7 +517,7 @@ impl CPU {
     }
 
     fn php(&mut self) {
-        //http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior
+        //https://www.nesdev.org/wiki/Status_flags
         let mut flags = self.status.clone();
         flags.insert(CpuFlags::BREAK);
         flags.insert(CpuFlags::BREAK2);

--- a/code/ch6.1/src/ppu/mod.rs
+++ b/code/ch6.1/src/ppu/mod.rs
@@ -248,7 +248,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x88);
     }
 
-    // Horizontal: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Horizontal: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 a ]
     //   [0x2800 B ] [0x2C00 b ]
     #[test]
@@ -277,7 +277,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x77); //read from b
     }
 
-    // Vertical: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Vertical: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 B ]
     //   [0x2800 a ] [0x2C00 b ]
     #[test]

--- a/code/ch6.2/src/cpu.rs
+++ b/code/ch6.2/src/cpu.rs
@@ -3,7 +3,7 @@ use crate::opcodes;
 use std::collections::HashMap;
 
 bitflags! {
-    /// # Status Register (P) http://wiki.nesdev.com/w/index.php/Status_flags
+    /// # Status Register (P) https://www.nesdev.org/wiki/Status_flags
     ///
     ///  7 6 5 4 3 2 1 0
     ///  N V _ B D I Z C

--- a/code/ch6.2/src/cpu.rs
+++ b/code/ch6.2/src/cpu.rs
@@ -573,7 +573,7 @@ impl CPU {
     }
 
     fn php(&mut self) {
-        //http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior
+        //https://www.nesdev.org/wiki/Status_flags
         let mut flags = self.status.clone();
         flags.insert(CpuFlags::BREAK);
         flags.insert(CpuFlags::BREAK2);

--- a/code/ch6.2/src/ppu/mod.rs
+++ b/code/ch6.2/src/ppu/mod.rs
@@ -291,7 +291,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x88);
     }
 
-    // Horizontal: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Horizontal: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 a ]
     //   [0x2800 B ] [0x2C00 b ]
     #[test]
@@ -320,7 +320,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x77); //read from b
     }
 
-    // Vertical: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Vertical: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 B ]
     //   [0x2800 a ] [0x2C00 b ]
     #[test]

--- a/code/ch6.3/src/cpu.rs
+++ b/code/ch6.3/src/cpu.rs
@@ -3,7 +3,7 @@ use crate::opcodes;
 use std::collections::HashMap;
 
 bitflags! {
-    /// # Status Register (P) http://wiki.nesdev.com/w/index.php/Status_flags
+    /// # Status Register (P) https://www.nesdev.org/wiki/Status_flags
     ///
     ///  7 6 5 4 3 2 1 0
     ///  N V _ B D I Z C

--- a/code/ch6.3/src/cpu.rs
+++ b/code/ch6.3/src/cpu.rs
@@ -573,7 +573,7 @@ impl CPU {
     }
 
     fn php(&mut self) {
-        //http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior
+        //https://www.nesdev.org/wiki/Status_flags
         let mut flags = self.status.clone();
         flags.insert(CpuFlags::BREAK);
         flags.insert(CpuFlags::BREAK2);

--- a/code/ch6.3/src/ppu/mod.rs
+++ b/code/ch6.3/src/ppu/mod.rs
@@ -291,7 +291,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x88);
     }
 
-    // Horizontal: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Horizontal: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 a ]
     //   [0x2800 B ] [0x2C00 b ]
     #[test]
@@ -320,7 +320,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x77); //read from b
     }
 
-    // Vertical: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Vertical: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 B ]
     //   [0x2800 a ] [0x2C00 b ]
     #[test]

--- a/code/ch6.4/src/bus.rs
+++ b/code/ch6.4/src/bus.rs
@@ -169,7 +169,7 @@ impl Mem for Bus<'_> {
                 // ignore joypad 2
             }
 
-            // https://wiki.nesdev.com/w/index.php/PPU_programmer_reference#OAM_DMA_.28.244014.29_.3E_write
+            // https://www.nesdev.org/wiki/PPU_programmer_reference#OAMDMA_-_Sprite_DMA_($4014_write)
             0x4014 => {
                 let mut buffer: [u8; 256] = [0; 256];
                 let hi: u16 = (data as u16) << 8;

--- a/code/ch6.4/src/cpu.rs
+++ b/code/ch6.4/src/cpu.rs
@@ -573,7 +573,7 @@ impl<'a> CPU<'a> {
     }
 
     fn php(&mut self) {
-        //http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior
+        //https://www.nesdev.org/wiki/Status_flags
         let mut flags = self.status.clone();
         flags.insert(CpuFlags::BREAK);
         flags.insert(CpuFlags::BREAK2);

--- a/code/ch6.4/src/cpu.rs
+++ b/code/ch6.4/src/cpu.rs
@@ -3,7 +3,7 @@ use crate::opcodes;
 use std::collections::HashMap;
 
 bitflags! {
-    /// # Status Register (P) http://wiki.nesdev.com/w/index.php/Status_flags
+    /// # Status Register (P) https://www.nesdev.org/wiki/Status_flags
     ///
     ///  7 6 5 4 3 2 1 0
     ///  N V _ B D I Z C

--- a/code/ch6.4/src/ppu/mod.rs
+++ b/code/ch6.4/src/ppu/mod.rs
@@ -290,7 +290,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x88);
     }
 
-    // Horizontal: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Horizontal: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 a ]
     //   [0x2800 B ] [0x2C00 b ]
     #[test]
@@ -319,7 +319,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x77); //read from b
     }
 
-    // Vertical: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Vertical: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 B ]
     //   [0x2800 a ] [0x2C00 b ]
     #[test]

--- a/code/ch7/src/bus.rs
+++ b/code/ch7/src/bus.rs
@@ -169,7 +169,7 @@ impl Mem for Bus<'_> {
                 // ignore joypad 2
             }
 
-            // https://wiki.nesdev.com/w/index.php/PPU_programmer_reference#OAM_DMA_.28.244014.29_.3E_write
+            // https://www.nesdev.org/wiki/PPU_programmer_reference#OAMDMA_-_Sprite_DMA_($4014_write)
             0x4014 => {
                 let mut buffer: [u8; 256] = [0; 256];
                 let hi: u16 = (data as u16) << 8;

--- a/code/ch7/src/cpu.rs
+++ b/code/ch7/src/cpu.rs
@@ -576,7 +576,7 @@ impl<'a> CPU<'a> {
     }
 
     fn php(&mut self) {
-        //http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior
+        //https://www.nesdev.org/wiki/Status_flags
         let mut flags = self.status.clone();
         flags.insert(CpuFlags::BREAK);
         flags.insert(CpuFlags::BREAK2);

--- a/code/ch7/src/cpu.rs
+++ b/code/ch7/src/cpu.rs
@@ -3,7 +3,7 @@ use crate::opcodes;
 use std::collections::HashMap;
 
 bitflags! {
-    /// # Status Register (P) http://wiki.nesdev.com/w/index.php/Status_flags
+    /// # Status Register (P) https://www.nesdev.org/wiki/Status_flags
     ///
     ///  7 6 5 4 3 2 1 0
     ///  N V _ B D I Z C

--- a/code/ch7/src/joypad.rs
+++ b/code/ch7/src/joypad.rs
@@ -1,5 +1,5 @@
 bitflags! {
-    // https://wiki.nesdev.com/w/index.php/Controller_reading_code
+    // https://www.nesdev.org/wiki/Controller_reading_code
     pub struct JoypadButton: u8 {
         const RIGHT             = 0b10000000;
         const LEFT              = 0b01000000;

--- a/code/ch7/src/ppu/mod.rs
+++ b/code/ch7/src/ppu/mod.rs
@@ -283,7 +283,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x88);
     }
 
-    // Horizontal: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Horizontal: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 a ]
     //   [0x2800 B ] [0x2C00 b ]
     #[test]
@@ -312,7 +312,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x77); //read from b
     }
 
-    // Vertical: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Vertical: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 B ]
     //   [0x2800 a ] [0x2C00 b ]
     #[test]

--- a/code/ch8/src/bus.rs
+++ b/code/ch8/src/bus.rs
@@ -173,7 +173,7 @@ impl Mem for Bus<'_> {
                 // ignore joypad 2
             }
 
-            // https://wiki.nesdev.com/w/index.php/PPU_programmer_reference#OAM_DMA_.28.244014.29_.3E_write
+            // https://www.nesdev.org/wiki/PPU_programmer_reference#OAMDMA_-_Sprite_DMA_($4014_write)
             0x4014 => {
                 let mut buffer: [u8; 256] = [0; 256];
                 let hi: u16 = (data as u16) << 8;

--- a/code/ch8/src/cpu.rs
+++ b/code/ch8/src/cpu.rs
@@ -3,7 +3,7 @@ use crate::opcodes;
 use std::collections::HashMap;
 
 bitflags! {
-    /// # Status Register (P) http://wiki.nesdev.com/w/index.php/Status_flags
+    /// # Status Register (P) https://www.nesdev.org/wiki/Status_flags
     ///
     ///  7 6 5 4 3 2 1 0
     ///  N V _ B D I Z C

--- a/code/ch8/src/cpu.rs
+++ b/code/ch8/src/cpu.rs
@@ -586,7 +586,7 @@ impl<'a> CPU<'a> {
     }
 
     fn php(&mut self) {
-        //http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior
+        //https://www.nesdev.org/wiki/Status_flags
         let mut flags = self.status.clone();
         flags.insert(CpuFlags::BREAK);
         flags.insert(CpuFlags::BREAK2);

--- a/code/ch8/src/joypad.rs
+++ b/code/ch8/src/joypad.rs
@@ -1,5 +1,5 @@
 bitflags! {
-    // https://wiki.nesdev.com/w/index.php/Controller_reading_code
+    // https://www.nesdev.org/wiki/Controller_reading_code
     pub struct JoypadButton: u8 {
         const RIGHT             = 0b10000000;
         const LEFT              = 0b01000000;

--- a/code/ch8/src/ppu/mod.rs
+++ b/code/ch8/src/ppu/mod.rs
@@ -294,7 +294,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x88);
     }
 
-    // Horizontal: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Horizontal: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 a ]
     //   [0x2800 B ] [0x2C00 b ]
     #[test]
@@ -323,7 +323,7 @@ pub mod test {
         assert_eq!(ppu.read_data(), 0x77); //read from b
     }
 
-    // Vertical: https://wiki.nesdev.com/w/index.php/Mirroring
+    // Vertical: https://www.nesdev.org/wiki/Mirroring
     //   [0x2000 A ] [0x2400 B ]
     //   [0x2800 a ] [0x2C00 b ]
     #[test]

--- a/src/chapter_1.md
+++ b/src/chapter_1.md
@@ -34,7 +34,7 @@ It's also assumed that the reader has a basic understanding of bit arithmetic, b
 
 # References
 
-1. [Nesdev Wiki](http://wiki.nesdev.com/w/index.php/Nesdev_Wiki) - nothing would be possible without it. The one-stop-shop.
+1. [Nesdev Wiki](https://www.nesdev.org/wiki/Nesdev_Wiki) - nothing would be possible without it. The one-stop-shop.
 2. [Nintendo Entertainment System Documentation](http://nesdev.com/NESDoc.pdf) - a short tutorial that covers pretty much everything about NES
 3. [Nintendo Age Nerdy Nights](https://nerdy-nights.nes.science/) - a series to help people write games for the NES
 4. [I.Am.Error](https://www.goodreads.com/book/show/23461364-i-am-error) - a book full of histories of the Nintendo Entertainment System platform

--- a/src/chapter_1.md
+++ b/src/chapter_1.md
@@ -35,7 +35,7 @@ It's also assumed that the reader has a basic understanding of bit arithmetic, b
 # References
 
 1. [Nesdev Wiki](https://www.nesdev.org/wiki/Nesdev_Wiki) - nothing would be possible without it. The one-stop-shop.
-2. [Nintendo Entertainment System Documentation](http://nesdev.com/NESDoc.pdf) - a short tutorial that covers pretty much everything about NES
+2. [Nintendo Entertainment System Documentation](https://www.nesdev.org/NESDoc.pdf) - a short tutorial that covers pretty much everything about NES
 3. [Nintendo Age Nerdy Nights](https://nerdy-nights.nes.science/) - a series to help people write games for the NES
 4. [I.Am.Error](https://www.goodreads.com/book/show/23461364-i-am-error) - a book full of histories of the Nintendo Entertainment System platform
 5. [The Elements of Computing Systems](https://www.goodreads.com/book/show/910789.The_Elements_of_Computing_Systems) - everything you need to know about computer systems, how to build Tetris starting from logic gates.

--- a/src/chapter_3_3.md
+++ b/src/chapter_3_3.md
@@ -15,7 +15,7 @@ Just some remarks:
 `A - B = A + (-B)`.
 And `-B = !B + 1`
 
-* **PHP**, **PLP** and **RTI** have to deal with [2 bit B-flag](http://wiki.nesdev.com/w/index.php/Status_flags#The_B_flag). Except for interrupts execution, those are the only commands that directly influence (or being directly influenced by) the 5th bit of **Status register P**
+* **PHP**, **PLP** and **RTI** have to deal with [2 bit B-flag](https://www.nesdev.org/wiki/Status_flags#The_B_flag). Except for interrupts execution, those are the only commands that directly influence (or being directly influenced by) the 5th bit of **Status register P**
 
 * The majority of the branching and jumping operations can be implemented by simply modifying the **program_counter** register. However, be careful not to increment the register within the same instruction interpret cycle.
 

--- a/src/chapter_5_1.md
+++ b/src/chapter_5_1.md
@@ -170,7 +170,7 @@ Here is the bad news: there are about 110 unofficial CPU instructions. Most of t
 
 The specs can be found here:
 * [nesdev.com/undocumented_opcodes.txt](http://nesdev.com/undocumented_opcodes.txt)
-* [wiki.nesdev.com/w/index.php/Programming_with_unofficial_opcodes](https://wiki.nesdev.com/w/index.php/Programming_with_unofficial_opcodes)
+* [wiki.nesdev.com/w/index.php/Programming_with_unofficial_opcodes](https://www.nesdev.org/wiki/Programming_with_unofficial_opcodes)
 * [wiki.nesdev.com/w/index.php/CPU_unofficial_opcodes](https://www.nesdev.org/wiki/CPU_unofficial_opcodes)
 * [www.oxyron.de/html/opcodes02.html](http://www.oxyron.de/html/opcodes02.html)
 

--- a/src/chapter_5_1.md
+++ b/src/chapter_5_1.md
@@ -171,7 +171,7 @@ Here is the bad news: there are about 110 unofficial CPU instructions. Most of t
 The specs can be found here:
 * [nesdev.com/undocumented_opcodes.txt](http://nesdev.com/undocumented_opcodes.txt)
 * [wiki.nesdev.com/w/index.php/Programming_with_unofficial_opcodes](https://wiki.nesdev.com/w/index.php/Programming_with_unofficial_opcodes)
-* [wiki.nesdev.com/w/index.php/CPU_unofficial_opcodes](https://wiki.nesdev.com/w/index.php/CPU_unofficial_opcodes)
+* [wiki.nesdev.com/w/index.php/CPU_unofficial_opcodes](https://www.nesdev.org/wiki/CPU_unofficial_opcodes)
 * [www.oxyron.de/html/opcodes02.html](http://www.oxyron.de/html/opcodes02.html)
 
 

--- a/src/chapter_5_1.md
+++ b/src/chapter_5_1.md
@@ -1,6 +1,6 @@
 # Running our first test ROM
 
-The NES dev community has created [large suites of tests](https://wiki.nesdev.com/w/index.php/Emulator_tests) that can be used to check our emulator.
+The NES dev community has created [large suites of tests](https://www.nesdev.org/wiki/Emulator_tests) that can be used to check our emulator.
 
 They cover pretty much every aspect of the console, including quirks and notable bugs that were embedded in the platform.
 
@@ -169,9 +169,9 @@ It looks like our CPU doesn't know how to interpret the opcode 0x04.
 Here is the bad news: there are about 110 unofficial CPU instructions. Most of the real NES games use them a lot. For us to move on, we will need to implement all of them.
 
 The specs can be found here:
-* [nesdev.com/undocumented_opcodes.txt](http://nesdev.com/undocumented_opcodes.txt)
-* [wiki.nesdev.com/w/index.php/Programming_with_unofficial_opcodes](https://www.nesdev.org/wiki/Programming_with_unofficial_opcodes)
-* [wiki.nesdev.com/w/index.php/CPU_unofficial_opcodes](https://www.nesdev.org/wiki/CPU_unofficial_opcodes)
+* [nesdev.org/undocumented_opcodes.txt](https://www.nesdev.org/undocumented_opcodes.txt)
+* [nesdev.org/wiki/Programming_with_unofficial_opcodes](https://www.nesdev.org/wiki/Programming_with_unofficial_opcodes)
+* [nesdev.org/wiki/CPU_unofficial_opcodes](https://www.nesdev.org/wiki/CPU_unofficial_opcodes)
 * [www.oxyron.de/html/opcodes02.html](http://www.oxyron.de/html/opcodes02.html)
 
 

--- a/src/chapter_6_1.md
+++ b/src/chapter_6_1.md
@@ -21,7 +21,7 @@ To be precise, PPU has its own bus used to communicate with RAM and cartridge CH
 One read-only register is used for reporting PPU status:
 * Status 0x2002
 
-The full spec of the registers can be found on [NES Dev wiki](http://wiki.nesdev.com/w/index.php/PPU_registers).
+The full spec of the registers can be found on [NES Dev wiki](https://www.nesdev.org/wiki/PPU_registers).
 
  <div style="text-align:center"><img src="./images/ch6.1/image_2_cpu_ppu_communication.png" width="70%"/></div>
 

--- a/src/chapter_6_1.md
+++ b/src/chapter_6_1.md
@@ -326,7 +326,7 @@ Writing to PPU memory can be implemented in a similar way, just don't forget tha
 
 One thing that isn't covered is how ```mirror_vram_addr``` is implemented.
 
-Again the NESDEV wiki provides excellent coverage of this topic: [Mirroring](http://wiki.nesdev.com/w/index.php/Mirroring).
+Again the NESDEV wiki provides excellent coverage of this topic: [Mirroring](https://www.nesdev.org/wiki/Mirroring).
 
 VRAM mirroring is tightly coupled with the way NES implements scrolling of the viewport.
 We would spend enough time discussing this in the chapter about Scroll.

--- a/src/chapter_6_2.md
+++ b/src/chapter_6_2.md
@@ -25,7 +25,7 @@ The NMI interrupt is tightly connected to PPU clock cycles:
 * upon entering scanline 241, PPU triggers NMI interrupt
 * PPU clock cycles are 3 times faster than CPU clock cycles
 
-Nothing beats NESDev wiki in providing [details on line-by-line timing](http://wiki.nesdev.com/w/index.php/PPU_rendering#Line-by-line_timing)
+Nothing beats NESDev wiki in providing [details on line-by-line timing](https://www.nesdev.org/wiki/PPU_rendering#Line-by-line_timing)
 
 But to simplify,
  * each PPU frame takes ```341*262=89342 PPU clocks cycles```
@@ -40,7 +40,7 @@ The emulator can take multiple approaches to simulate this behavior:
 
 2) Execute all components sequentially in one thread, by advancing one clock cycle at a time in each component. This is similar to creating a green-thread runtime and using one dedicated OS thread to run this runtime. It would require substantial investment in creating green-threads runtime.
 
-3) Execute all components sequentially in one thread, but by letting CPU to execute one full instruction, compute the clock cycles budget for other components and let them run within the budget. This technique is called ["catch-up"](http://wiki.nesdev.com/w/index.php/Catch-up) <br/> <br/>For example, CPU takes 2 cycles to execute "LDA #$01" (opcode 0xA9), which means that PPU can run for 6 PPU cycles now (PPU clock is ticking three times faster than CPU clock) and APU can run for 1 cycle (APU clock is two times slower)
+3) Execute all components sequentially in one thread, but by letting CPU to execute one full instruction, compute the clock cycles budget for other components and let them run within the budget. This technique is called ["catch-up"](https://www.nesdev.org/wiki/Catch-up) <br/> <br/>For example, CPU takes 2 cycles to execute "LDA #$01" (opcode 0xA9), which means that PPU can run for 6 PPU cycles now (PPU clock is ticking three times faster than CPU clock) and APU can run for 1 cycle (APU clock is two times slower)
 
 Because we already have CPU loop mostly spec'd out, the third approach is the easiest to implement. Granted, it would be the least accurate one. But it's good enough to have something playable as soon as possible.
 
@@ -226,7 +226,7 @@ impl PPU for NesPPU {
 
 In our CPU implementation, we've implemented opcode **0x00** as a return from CPU fetch-decode-execute cycle, but in reality it should trigger BRK interrupt. This is so-called "software interrupt" that a game code can trigger programmatically in response to events.
 
-NESDEV Wiki provides all necessary details about [CPU interrupts](https://wiki.nesdev.com/w/index.php/CPU_interrupts).
+NESDEV Wiki provides all necessary details about [CPU interrupts](https://www.nesdev.org/wiki/CPU_interrupts).
 
 <br/>
 

--- a/src/chapter_6_3.md
+++ b/src/chapter_6_3.md
@@ -43,7 +43,7 @@ To figure out the color index of the top-left pixel, we need to read the 7th bit
 Before rendering CHR ROM content, we need to briefly discuss the colors available to the NES.
 Different versions of the PPU chip had slightly different system-level palettes of 52 hardwired colors.
 
-All necessary details can be found on corresponding [NesDev wiki page](http://wiki.nesdev.com/w/index.php/PPU_palettes#Palettes).
+All necessary details can be found on corresponding [NesDev wiki page](https://www.nesdev.org/wiki/PPU_palettes#Palettes).
 
 
 <div style="text-align:center"><img src="./images/ch6.3/image_6_system_palette.png" width="50%"/></div>

--- a/src/chapter_6_4.md
+++ b/src/chapter_6_4.md
@@ -291,7 +291,7 @@ CPU has two options for updating the OAM Table:
 
 In comparison to background tiles, a sprite tile can be shown anywhere in a 256x240 screen. Each OAM record has 2 bytes reserved for X and Y coordinates, one byte is used to select a tile pattern from the pattern table. And the remaining byte specifies how the object should be drawn (for example, PPU can flip same tile horizontally or vertically)
 
-NES Dev Wiki provides a pretty solid specification of [each byte in the OAM record](http://wiki.nesdev.com/w/index.php/PPU_OAM)
+NES Dev Wiki provides a pretty solid specification of [each byte in the OAM record](https://www.nesdev.org/wiki/PPU_OAM)
 
 To render all visible sprites, we just need to scan through oam_data space and parse out every 4 bytes into a sprite:
 

--- a/src/chapter_6_4.md
+++ b/src/chapter_6_4.md
@@ -36,7 +36,7 @@ Each tile is represented by one byte in VRAM in the space called Nametable.
 In addition to 960 bytes for tiles, a nametable holds 64 bytes that specify color palette, we will discuss later. In total, a single frame is defined as 1024 bytes (960 + 64). PPU VRAM can simultaneously hold two nametables - the states of two frames.
 
 Two additional nametables that exist in the address space of the PPU must be either mapped to existing tables or to extra RAM space on a cartridge.
-[More details](http://wiki.nesdev.com/w/index.php/Mirroring).
+[More details](https://www.nesdev.org/wiki/Mirroring).
 
 Nametables are populated by CPU during program execution (using Addr and Data registers that we've implemented). It's entirely determined by game code. All we need to do is to read the correct part of the VRAM.
 

--- a/src/chapter_6_4.md
+++ b/src/chapter_6_4.md
@@ -92,7 +92,7 @@ Again, we need to intercept the program execution to read the screen state.
 On the real console the PPU is drawing one pixel each PPU clock cycle. However, we can take a shortcut. Instead of reading part of the screen state on each PPU clock tick, we can wait until the full screen is ready and read in one go.
 
 > **WARNING** This is quite a drastic simplification that limits the types of games it will be possible to play on the emulator. </br><br/>More advanced games used a lot of tricks to enrich the gaming experience.
-> For example, changing scroll in the middle of the frame (<a href="https://wiki.nesdev.com/w/index.php/PPU_scrolling#Split_X_scroll">split scroll</a>) or changing palette colors. <br/><br/>
+> For example, changing scroll in the middle of the frame (<a href="https://www.nesdev.org/wiki/PPU_scrolling#Split_X_scroll">split scroll</a>) or changing palette colors. <br/><br/>
 > This simplification wouldn't affect first-gen NES games much. The majority of NES games would require more accuracy in PPU emulation, however.
 
 On the real console, PPU is actively drawing screen state on a TV screen during 0 - 240 scanlines; during scanlines 241 - 262, the CPU is updating the state of PPU for the next frame, then the cycle repeats.

--- a/src/chapter_7.md
+++ b/src/chapter_7.md
@@ -41,7 +41,7 @@ We need 1 byte to store the status of all buttons:
 
 ```rust
 bitflags! {
-       // https://wiki.nesdev.com/w/index.php/Controller_reading_code
+       // https://www.nesdev.org/wiki/Controller_reading_code
        pub struct JoypadButton: u8 {
            const RIGHT             = 0b10000000;
            const LEFT              = 0b01000000;

--- a/src/chapter_8.md
+++ b/src/chapter_8.md
@@ -2,10 +2,10 @@
 
 Before we start discussing scrolling, we need to clarify one detail. We've discussed that PPU notifies the state of the frame by triggering NMI interrupt, which tells CPU that rendering of the current frame is finished.
 That's not the whole story. PPU has 2 additional mechanisms to tell its progress:
-* [sprite zero hit flag](https://wiki.nesdev.com/w/index.php?title=PPU_OAM&redirect=no#Sprite_zero_hits)
-* [sprite overflow flag](https://wiki.nesdev.com/w/index.php/PPU_sprite_evaluation#Sprite_overflow_bug)
+* [sprite zero hit flag](https://www.nesdev.org/wiki/PPU_OAM#Sprite_zero_hits)
+* [sprite overflow flag](https://www.nesdev.org/wiki/PPU_sprite_evaluation#Sprite_overflow_bug)
 
-Both are reported using [PPU status register **0x2002**](https://wiki.nesdev.com/w/index.php/PPU_registers#Status_.28.242002.29_.3C_read)
+Both are reported using [PPU status register **0x2002**](https://www.nesdev.org/wiki/PPU_registers#PPUSTATUS_-_Rendering_events_($2002_read))
 
 <div style="text-align:center;"><img src="./images/ch8/image_7_sprite_0_hit.png" width="60%"/></div>
 


### PR DESCRIPTION
This PR updates outdated NESdev Wiki links from nesdev.com to nesdev.org.

- According to the wiki's log (2021-10-16), there was an ongoing effort to clarify the ownership of the nesdev.com domain. But the .com domain is still unavailable (2026-06-20).
  - ref: https://www.nesdev.org/wiki/Nesdev_Wiki 
